### PR TITLE
some changes to Singleton implementation

### DIFF
--- a/src/profile_manager.cpp
+++ b/src/profile_manager.cpp
@@ -3,24 +3,22 @@
 
 using namespace profiler;
 
-ProfileManager*  ProfileManager::m_profileManager = nullptr;
-
 extern "C"{
 
-	void PROFILER_API registerMark(Mark* _mark)
-	{
-		ProfileManager::instance()->registerMark(_mark);
-	}
+    void PROFILER_API registerMark(Mark* _mark)
+    {
+        ProfileManager::instance().registerMark(_mark);
+    }
 
-	void PROFILER_API endBlock()
-	{
-		ProfileManager::instance()->endBlock();
-	}
+    void PROFILER_API endBlock()
+    {
+        ProfileManager::instance().endBlock();
+    }
 
-	void PROFILER_API setEnabled(bool isEnable)
-	{
-		ProfileManager::instance()->setEnabled(isEnable);
-	}
+    void PROFILER_API setEnabled(bool isEnable)
+    {
+        ProfileManager::instance().setEnabled(isEnable);
+    }
 }
 
 
@@ -29,15 +27,12 @@ ProfileManager::ProfileManager()
 
 }
 
-ProfileManager* ProfileManager::instance()
+ProfileManager& ProfileManager::instance()
 {
-	if (!m_profileManager)
-	{
-		//TODO: thread safety for profiler::instance
-		//if(!m_profiler)//see paper by Scott Mayers and Alecsandrescu: http://www.aristeia.com/Papers/DDJ_Jul_Aug_2004_revised.pdf
-		m_profileManager = new ProfileManager();
-	}
-	return m_profileManager;
+    ///C++11 makes possible to create Singleton without any warry about thread-safeness
+    ///http://preshing.com/20130930/double-checked-locking-is-fixed-in-cpp11/
+    static ProfileManager m_profileManager;
+    return m_profileManager;
 }
 
 void ProfileManager::registerMark(profiler::Mark* _mark)
@@ -52,5 +47,5 @@ void ProfileManager::endBlock()
 
 void ProfileManager::setEnabled(bool isEnable)
 {
-	m_isEnabled = isEnable;
+    m_isEnabled = isEnable;
 }

--- a/src/profile_manager.h
+++ b/src/profile_manager.h
@@ -26,11 +26,11 @@ class ProfileManager
 	ProfileManager();
 	ProfileManager(const ProfileManager& p) = delete;
 	ProfileManager& operator=(const ProfileManager&) = delete;
-	static ProfileManager* m_profileManager;
+    static ProfileManager m_profileManager;
 
 	bool m_isEnabled = false;
 public:
-	static ProfileManager* instance();
+    static ProfileManager& instance();
 
 	void registerMark(profiler::Mark* _mark);
 	void endBlock();


### PR DESCRIPTION
In c++11 we have memory and thread safe for implementation of Singleton pattern by default with using static defenition.