### PR TITLE
Fixes for clang 3.8.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ include_directories(
 
 if(UNIX)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-long-long -Wno-reorder -pedantic -O3" )
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-long-long -Wno-reorder -Wno-braced-scalar-init -pedantic -O3" )
 else()
     add_definitions(
         -D_CRT_SECURE_NO_WARNINGS

--- a/easy_profiler_core/include/easy/easy_socket.h
+++ b/easy_profiler_core/include/easy/easy_socket.h
@@ -79,7 +79,6 @@ private:
     
     socket_t m_socket = 0;
     socket_t m_replySocket = 0;
-    uint16_t m_port = 0;
 
     int wsaret = -1;
 

--- a/easy_profiler_core/profile_manager.cpp
+++ b/easy_profiler_core/profile_manager.cpp
@@ -1066,7 +1066,7 @@ void ProfileManager::startListen(uint16_t _port)
     if (!m_isAlreadyListening.exchange(true, std::memory_order_release))
     {
         m_stopListen.store(false, std::memory_order_release);
-        m_listenThread = std::move(std::thread(&ProfileManager::listen, this, _port));
+        m_listenThread = std::thread(&ProfileManager::listen, this, _port);
     }
 }
 

--- a/easy_profiler_core/profile_manager.h
+++ b/easy_profiler_core/profile_manager.h
@@ -382,8 +382,6 @@ class ProfileManager
     std::thread m_listenThread;
     void listen(uint16_t _port);
 
-    int m_socket = 0;//TODO crossplatform
-
     std::atomic_bool m_stopListen;
 
 public:

--- a/easy_profiler_core/reader.cpp
+++ b/easy_profiler_core/reader.cpp
@@ -697,7 +697,6 @@ extern "C" {
                             root.children.erase(lower, root.children.end());
                             EASY_END_BLOCK;
 
-                            ::profiler::timestamp_t children_duration = 0;
                             if (gather_statistics)
                             {
                                 EASY_BLOCK("Gather statistic within parent", ::profiler::colors::Magenta);

--- a/profiler_gui/easy_graphics_item.cpp
+++ b/profiler_gui/easy_graphics_item.cpp
@@ -510,10 +510,10 @@ void EasyGraphicsItem::paint(QPainter* _painter, const QStyleOptionGraphicsItem*
     // Iterate through layers and draw visible items
     if (gotItems)
     {
-        static const auto MAX_CHILD_INDEX = ::profiler_gui::numeric_max<decltype(::profiler_gui::EasyBlockItem::children_begin)>();
         const int narrow_size_half = EASY_GLOBALS.blocks_narrow_size >> 1;
 
 #ifndef EASY_GRAPHICS_ITEM_RECURSIVE_PAINT
+        static const auto MAX_CHILD_INDEX = ::profiler_gui::numeric_max<decltype(::profiler_gui::EasyBlockItem::children_begin)>();
         auto const dont_skip_children = [this, &levelsNumber](short next_level, decltype(::profiler_gui::EasyBlockItem::children_begin) children_begin, int8_t _state)
         {
             if (next_level < levelsNumber && children_begin != MAX_CHILD_INDEX)
@@ -539,7 +539,6 @@ void EasyGraphicsItem::paint(QPainter* _painter, const QStyleOptionGraphicsItem*
         {
             auto& level = m_levels[l];
             const short next_level = l + 1;
-            char state = BLOCK_ITEM_DO_PAINT;
 
             const auto top = levelY(l);
             if (top > p.visibleBottom)
@@ -558,6 +557,7 @@ void EasyGraphicsItem::paint(QPainter* _painter, const QStyleOptionGraphicsItem*
                     break; // This is first totally invisible item. No need to check other items.
 
 #ifndef EASY_GRAPHICS_ITEM_RECURSIVE_PAINT
+                char state = BLOCK_ITEM_DO_PAINT;
                 if (item.state != BLOCK_ITEM_UNCHANGED)
                 {
                     neighbour = 0; // first block in parent's children list

--- a/profiler_gui/easy_graphics_scrollbar.cpp
+++ b/profiler_gui/easy_graphics_scrollbar.cpp
@@ -835,7 +835,7 @@ void EasyHystogramItem::setSource(::profiler::thread_id_t _thread_id, ::profiler
         show();
         m_timeUnits = EASY_GLOBALS.time_units;
         m_bReady.store(false, ::std::memory_order_release);
-        m_workerThread = ::std::move(::std::thread([this](decltype(root) profiler_thread)
+        m_workerThread = ::std::thread([this](decltype(root) profiler_thread)
         {
             typedef ::std::vector<::std::pair<::profiler::block_index_t, ::profiler::block_index_t> > Stack;
 
@@ -909,7 +909,7 @@ void EasyHystogramItem::setSource(::profiler::thread_id_t _thread_id, ::profiler
             }
 
             m_bReady.store(true, ::std::memory_order_release);
-        }, std::ref(root)));
+        }, std::ref(root));
 
         m_timeouts = 3;
         m_timer.start(500);
@@ -984,13 +984,13 @@ void EasyHystogramItem::updateImage()
     delete m_temporaryImage;
     m_temporaryImage = nullptr;
 
-    m_workerThread = ::std::move(::std::thread([this](HystRegime _regime, qreal _current_scale,
+    m_workerThread = ::std::thread([this](HystRegime _regime, qreal _current_scale,
         qreal _minimum, qreal _maximum, qreal _range, qreal _value, qreal _width, bool _bindMode,
         float _frame_time, ::profiler::timestamp_t _begin_time)
     {
         updateImage(_regime, _current_scale, _minimum, _maximum, _range, _value, _width, _bindMode, _frame_time, _begin_time);
         m_bReady.store(true, ::std::memory_order_release);
-    }, m_regime, widget->getWindowScale(), widget->minimum(), widget->maximum(), widget->range(), widget->value(), widget->sliderWidth(), widget->bindMode(), EASY_GLOBALS.frame_time, EASY_GLOBALS.begin_time));
+    }, m_regime, widget->getWindowScale(), widget->minimum(), widget->maximum(), widget->range(), widget->value(), widget->sliderWidth(), widget->bindMode(), EASY_GLOBALS.frame_time, EASY_GLOBALS.begin_time);
 
     m_timeouts = 3;
     m_timer.start(500);

--- a/profiler_gui/main_window.cpp
+++ b/profiler_gui/main_window.cpp
@@ -1328,12 +1328,12 @@ void EasyFileReader::load(const QString& _filename)
 
     m_isFile = true;
     m_filename = _filename;
-    m_thread = ::std::move(::std::thread([this](bool _enableStatistics) {
+    m_thread = ::std::thread([this](bool _enableStatistics) {
         m_size.store(fillTreesFromFile(m_progress, m_filename.toStdString().c_str(), m_serializedBlocks, m_serializedDescriptors,
             m_descriptors, m_blocks, m_blocksTree, m_descriptorsNumberInFile, _enableStatistics, m_errorMessage), ::std::memory_order_release);
         m_progress.store(100, ::std::memory_order_release);
         m_bDone.store(true, ::std::memory_order_release);
-    }, EASY_GLOBALS.enable_statistics));
+    }, EASY_GLOBALS.enable_statistics);
 }
 
 void EasyFileReader::load(::std::stringstream& _stream)
@@ -1343,7 +1343,7 @@ void EasyFileReader::load(::std::stringstream& _stream)
     m_isFile = false;
     m_filename.clear();
 
-#if defined(__GNUC__) && __GNUC__ < 5
+#if defined(__GNUC__) && __GNUC__ < 5 && !defined(__llvm__)
     // gcc 4 has a known bug which has been solved in gcc 5:
     // std::stringstream has no swap() method :(
     // have to copy all contents... Use gcc 5 or higher!
@@ -1353,7 +1353,7 @@ void EasyFileReader::load(::std::stringstream& _stream)
     m_stream.swap(_stream);
 #endif
 
-    m_thread = ::std::move(::std::thread([this](bool _enableStatistics) {
+    m_thread = ::std::thread([this](bool _enableStatistics) {
         ::std::ofstream cache_file(NETWORK_CACHE_FILE, ::std::fstream::binary);
         if (cache_file.is_open()) {
             cache_file << m_stream.str();
@@ -1363,7 +1363,7 @@ void EasyFileReader::load(::std::stringstream& _stream)
             m_blocks, m_blocksTree, m_descriptorsNumberInFile, _enableStatistics, m_errorMessage), ::std::memory_order_release);
         m_progress.store(100, ::std::memory_order_release);
         m_bDone.store(true, ::std::memory_order_release);
-    }, EASY_GLOBALS.enable_statistics));
+    }, EASY_GLOBALS.enable_statistics);
 }
 
 void EasyFileReader::interrupt()
@@ -1902,7 +1902,7 @@ bool EasySocketListener::startCapture()
     }
 
     m_regime = LISTENER_CAPTURE;
-    m_thread = ::std::move(::std::thread(&EasySocketListener::listenCapture, this));
+    m_thread = ::std::thread(&EasySocketListener::listenCapture, this);
 
     return true;
 }

--- a/profiler_gui/tree_widget_loader.cpp
+++ b/profiler_gui/tree_widget_loader.cpp
@@ -157,18 +157,18 @@ void EasyTreeWidgetLoader::fillTree(::profiler::timestamp_t& _beginTime, const u
 {
     interrupt();
     m_mode = _mode;
-    m_thread = ::std::move(::std::thread(&EasyTreeWidgetLoader::setTreeInternal1, this,
+    m_thread = ::std::thread(&EasyTreeWidgetLoader::setTreeInternal1, this,
         ::std::ref(_beginTime), _blocksNumber, ::std::ref(_blocksTree), _colorizeRows,
-        EASY_GLOBALS.add_zero_blocks_to_hierarchy, EASY_GLOBALS.use_decorated_thread_name, EASY_GLOBALS.time_units));
+        EASY_GLOBALS.add_zero_blocks_to_hierarchy, EASY_GLOBALS.use_decorated_thread_name, EASY_GLOBALS.time_units);
 }
 
 void EasyTreeWidgetLoader::fillTreeBlocks(const::profiler_gui::TreeBlocks& _blocks, ::profiler::timestamp_t _beginTime, ::profiler::timestamp_t _left, ::profiler::timestamp_t _right, bool _strict, bool _colorizeRows, EasyTreeMode _mode)
 {
     interrupt();
     m_mode = _mode;
-    m_thread = ::std::move(::std::thread(&EasyTreeWidgetLoader::setTreeInternal2, this,
+    m_thread = ::std::thread(&EasyTreeWidgetLoader::setTreeInternal2, this,
         _beginTime, ::std::ref(_blocks), _left, _right, _strict, _colorizeRows,
-        EASY_GLOBALS.add_zero_blocks_to_hierarchy, EASY_GLOBALS.use_decorated_thread_name, EASY_GLOBALS.time_units));
+        EASY_GLOBALS.add_zero_blocks_to_hierarchy, EASY_GLOBALS.use_decorated_thread_name, EASY_GLOBALS.time_units);
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -1,4 +1,5 @@
 project(profiler_sample)
+cmake_minimum_required(VERSION 2.8)
 
 set(CPP_FILES
     main.cpp
@@ -7,6 +8,13 @@ set(CPP_FILES
 set(SOURCES
     ${CPP_FILES}
 )
+
+include_directories(
+    ../easy_profiler_core/include
+)
+link_directories(${CMAKE_SOURCE_DIR}/../bin)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
 
 add_executable(${PROJECT_NAME} ${SOURCES})
 


### PR DESCRIPTION
- Disables warnings for no-braced-scalar-init which shows up for ATOMIC_VAR_INIT.
- Fixes compile warnings, mostly "moving a temporary objects prevents
  copy elision" (-Wpessimizing-move) and unused variables.
- Adds some necessary fields to make the sample compile after having
  build the core library.