### PR TITLE
Getters (API) + compile error fix

### DIFF
--- a/easy_profiler_core/event_trace_win.h
+++ b/easy_profiler_core/event_trace_win.h
@@ -95,6 +95,7 @@ namespace profiler {
         ::profiler::EventTracingEnableStatus enable(bool _force = false);
         void disable();
         void setLowPriority(bool _value);
+        bool getLowPriority();
         static void setProcessPrivileges();
 
     private:

--- a/easy_profiler_core/include/easy/easy_net.h
+++ b/easy_profiler_core/include/easy/easy_net.h
@@ -38,7 +38,7 @@ along with this program.If not, see <http://www.gnu.org/licenses/>.
 namespace profiler {
 namespace net {
 
-const char* DAFAULT_ADDRESS = "tcp://127.0.0.1:28077";
+#define DAFAULT_ADDRESS "tcp://127.0.0.1:28077"
 const uint32_t EASY_MESSAGE_SIGN = 20160909;
 
 #pragma pack(push,1)

--- a/easy_profiler_core/include/easy/profiler.h
+++ b/easy_profiler_core/include/easy/profiler.h
@@ -547,6 +547,7 @@ namespace profiler {
         \ingroup profiler
         */
         PROFILER_API void setEnabled(bool _isEnable);
+        PROFILER_API bool isEnabled();
 
         /** Save all gathered blocks into file.
 
@@ -581,6 +582,7 @@ namespace profiler {
         \ingroup profiler
         */
         PROFILER_API void setEventTracingEnabled(bool _isEnable);
+        PROFILER_API bool isEventTracingEnabled();
 
         /** Set event tracing thread priority (low or normal).
 
@@ -591,6 +593,7 @@ namespace profiler {
         \ingroup profiler
         */
         PROFILER_API void setLowPriorityEventTracing(bool _isLowPriority);
+        PROFILER_API bool isLowPriorityEventTracing();
 
         /** Set temporary log-file path for Unix event tracing system.
 
@@ -608,6 +611,7 @@ namespace profiler {
 
         PROFILER_API void startListen(uint16_t _port = ::profiler::DEFAULT_PORT);
         PROFILER_API void stopListen();
+        PROFILER_API bool isListening();
 
         /** Returns current major version.
         
@@ -645,17 +649,21 @@ namespace profiler {
     { return reinterpret_cast<const BaseBlockDescriptor*>(0xbad); }
     inline void endBlock() { }
     inline void setEnabled(bool) { }
+    inline bool isEnabled(bool) { return false; }
     inline void storeEvent(const BaseBlockDescriptor*, const char*) { }
     inline void beginBlock(Block&) { }
     inline uint32_t dumpBlocksToFile(const char*) { return 0; }
     inline const char* registerThreadScoped(const char*, ThreadGuard&) { return ""; }
     inline const char* registerThread(const char*) { return ""; }
     inline void setEventTracingEnabled(bool) { }
+    inline bool isEventTracingEnabled() { return false; }
     inline void setLowPriorityEventTracing(bool) { }
+    inline bool isLowPriorityEventTracing() { return false; }
     inline void setContextSwitchLogFilename(const char*) { }
     inline const char* getContextSwitchLogFilename() { return ""; }
     inline void startListen(uint16_t = ::profiler::DEFAULT_PORT) { }
     inline void stopListen() { }
+    inline bool isListening() { return false; }
     inline uint8_t versionMajor() { return 0; }
     inline uint8_t versionMinor() { return 0; }
     inline uint16_t versionPatch() { return 0; }

--- a/easy_profiler_core/profile_manager.cpp
+++ b/easy_profiler_core/profile_manager.cpp
@@ -855,7 +855,7 @@ bool ProfileManager::isEnabled() const
 
 void ProfileManager::setEventTracingEnabled(bool _isEnable)
 {
-    m_isEventTracingEnabled.store(_isEnable, std::memory_order_acquire);
+    m_isEventTracingEnabled.store(_isEnable, std::memory_order_release);
 }
 
 bool ProfileManager::isEventTracingEnabled() const

--- a/easy_profiler_core/profile_manager.h
+++ b/easy_profiler_core/profile_manager.h
@@ -402,7 +402,9 @@ public:
     void beginBlock(profiler::Block& _block);
     void endBlock();
     void setEnabled(bool isEnable);
+    bool isEnabled() const;
     void setEventTracingEnabled(bool _isEnable);
+    bool isEventTracingEnabled() const;
     uint32_t dumpBlocksToFile(const char* filename);
     const char* registerThread(const char* name, profiler::ThreadGuard& threadGuard);
     const char* registerThread(const char* name);
@@ -421,6 +423,7 @@ public:
     void endContextSwitch(profiler::thread_id_t _thread_id, processid_t _process_id, profiler::timestamp_t _endtime, bool _lockSpin = true);
     void startListen(uint16_t _port);
     void stopListen();
+    bool isListening() const;
 
 private:
 


### PR DESCRIPTION
Added four getters to the API:

* bool getEnabled()
* bool getListening()
* bool getEventTracingEnabled()
* bool getLowPriorityEventTracing()

Also i had to change `const char* DAFAULT_ADDRESS` to `#define DAFAULT_ADDRESS` because on my system building vanilla `easy_profiler` failed complaining that multiple `DAFAULT_ADDRESS` symbols being defined.