### PR TITLE
Added the /WX flag, which treats compiler warnings as errors in MSVC.

### DIFF
--- a/easy_profiler_core/CMakeLists.txt
+++ b/easy_profiler_core/CMakeLists.txt
@@ -131,6 +131,10 @@ if (MINGW)
     target_compile_definitions(easy_profiler PRIVATE -DSTRSAFE_NO_DEPRECATE)
 endif ()
 
+if (MSVC)
+    target_compile_options(easy_profiler PRIVATE /WX)
+endif()
+
 if (APPLE)
     target_compile_options(easy_profiler PUBLIC -std=gnu++11)
 else ()

--- a/easy_profiler_core/easy_socket.cpp
+++ b/easy_profiler_core/easy_socket.cpp
@@ -248,7 +248,7 @@ int EasySocket::accept()
     fdexcl = fdread;
     tv.tv_sec = 0; tv.tv_usec = 500;
 
-    int rc =select (m_socket+1, &fdread, &fdwrite, &fdexcl, &tv);
+    int rc =select ((int)m_socket+1, &fdread, &fdwrite, &fdexcl, &tv);
 
     if(rc <= 0){
         //there is no connection for accept

--- a/easy_profiler_core/include/easy/reader.h
+++ b/easy_profiler_core/include/easy/reader.h
@@ -370,7 +370,7 @@ namespace profiler {
             other.m_size = m_size;
 
             m_data = d;
-            m_size = sz;
+            m_size = (size_t)sz;
         }
 
     private:


### PR DESCRIPTION
* This required a minor change to CMakeLists.txt.
* Also updated two occurrences in code where compilation failed due to
implicit narrowing conversions.

Tested on VS2015 and VS2017, though I can't see why it wouldn't work on older versions.