### PR TITLE
Moved QFonts into EASY_GLOBALS and deferred instantiation of EASY_GLOBAS

### DIFF
--- a/profiler_gui/blocks_graphics_view.cpp
+++ b/profiler_gui/blocks_graphics_view.cpp
@@ -100,9 +100,6 @@ const uint64_t IDLE_TIME = 400;
 const int FLICKER_INTERVAL = 10; // 100Hz
 const qreal FLICKER_FACTOR = 16.0 / FLICKER_INTERVAL;
 
-const auto BG_FONT = ::profiler_gui::EFont("Helvetica", 10, QFont::Bold);
-const auto CHRONOMETER_FONT = ::profiler_gui::EFont("Helvetica", 16, QFont::Bold);
-
 #ifdef max
 #undef max
 #endif
@@ -284,7 +281,7 @@ void EasyTimelineIndicatorItem::paint(QPainter* _painter, const QStyleOptionGrap
     _painter->drawLine(QLineF(visibleSceneRect.width() - 10, visibleSceneRect.height() - 6, visibleSceneRect.width() - 10, visibleSceneRect.height() - 14));
 
     _painter->setPen(Qt::black);
-    _painter->setFont(BG_FONT);
+    _painter->setFont(EASY_GLOBALS.bg_font);
     _painter->drawText(QRectF(visibleSceneRect.width() - 10 - step, visibleSceneRect.height() - 63, step, 50), Qt::AlignRight | Qt::AlignBottom | Qt::TextDontClip, text);
 
     _painter->restore();
@@ -2027,7 +2024,7 @@ void EasyThreadNameItem::paint(QPainter* _painter, const QStyleOptionGraphicsIte
 
     // Draw thread names
     auto default_font = _painter->font();
-    _painter->setFont(BG_FONT);
+    _painter->setFont(EASY_GLOBALS.bg_font);
     for (auto item : items)
     {
         ++i;
@@ -2082,8 +2079,8 @@ void EasyThreadNameItem::paint(QPainter* _painter, const QStyleOptionGraphicsIte
     _painter->drawLine(QLineF(0, h + 2, w, h + 2));
 
     // Draw information
-    _painter->setFont(CHRONOMETER_FONT);
-    QFontMetricsF fm(CHRONOMETER_FONT, parentView);
+    _painter->setFont(EASY_GLOBALS.chronometer_font);
+    QFontMetricsF fm(EASY_GLOBALS.chronometer_font, parentView);
     const qreal th = fm.height(); // Calculate displayed text height
     const qreal time1 = view->chronoTime();
     const qreal time2 = view->chronoTimeAux();
@@ -2184,7 +2181,7 @@ void EasyThreadNamesWidget::onTreeChange()
     m_idleTimer.stop();
     m_idleTime = 0;
 
-    QFontMetricsF fm(BG_FONT, this);
+    QFontMetricsF fm(EASY_GLOBALS.bg_font, this);
     qreal maxLength = 100;
     const auto& graphicsItems = m_view->getItems();
     for (auto graphicsItem : graphicsItems)

--- a/profiler_gui/easy_chronometer_item.cpp
+++ b/profiler_gui/easy_chronometer_item.cpp
@@ -62,8 +62,6 @@
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////
 
-const auto CHRONOMETER_FONT = ::profiler_gui::EFont("Helvetica", 16, QFont::Bold);
-
 #ifdef max
 #undef max
 #endif
@@ -152,7 +150,7 @@ void EasyChronometerItem::paint(QPainter* _painter, const QStyleOptionGraphicsIt
     selectedInterval = units2microseconds(selectedInterval);
 
     const QString text = ::profiler_gui::timeStringReal(EASY_GLOBALS.time_units, selectedInterval); // Displayed text
-    const auto textRect = QFontMetricsF(CHRONOMETER_FONT, sceneView).boundingRect(text); // Calculate displayed text boundingRect
+    const auto textRect = QFontMetricsF(EASY_GLOBALS.chronometer_font, sceneView).boundingRect(text); // Calculate displayed text boundingRect
     const auto rgb = m_color.rgb() & 0x00ffffff;
 
 
@@ -239,7 +237,7 @@ void EasyChronometerItem::paint(QPainter* _painter, const QStyleOptionGraphicsIt
     _painter->setCompositionMode(QPainter::CompositionMode_Difference); // This lets the text to be visible on every background
     _painter->setRenderHint(QPainter::TextAntialiasing);
     _painter->setPen(0x00ffffff - rgb);
-    _painter->setFont(CHRONOMETER_FONT);
+    _painter->setFont(EASY_GLOBALS.chronometer_font);
 
     int textFlags = 0;
     switch (EASY_GLOBALS.chrono_text_position)

--- a/profiler_gui/easy_graphics_item.cpp
+++ b/profiler_gui/easy_graphics_item.cpp
@@ -81,8 +81,6 @@ inline QRgb selectedItemBorderColor(::profiler::color_t _color) {
 }
 
 const QPen HIGHLIGHTER_PEN = ([]() -> QPen { QPen p(::profiler::colors::Black); p.setStyle(Qt::DotLine); p.setWidth(2); return p; })();
-const auto ITEMS_FONT = ::profiler_gui::EFont("Helvetica", 10, QFont::Medium);
-const auto SELECTED_ITEM_FONT = ::profiler_gui::EFont("Helvetica", 10, QFont::Bold);
 
 #ifdef max
 #undef max
@@ -418,7 +416,7 @@ void EasyGraphicsItem::paintChildren(const float _minWidth, const int _narrowSiz
         _painter->setPen(p.textColor);
 
         if (item.block == EASY_GLOBALS.selected_block)
-            _painter->setFont(SELECTED_ITEM_FONT);
+            _painter->setFont(EASY_GLOBALS.selected_item_font);
 
         // drawing text
         auto name = *itemBlock.tree.node->name() != 0 ? itemBlock.tree.node->name() : itemDesc.name();
@@ -436,7 +434,7 @@ void EasyGraphicsItem::paintChildren(const float _minWidth, const int _narrowSiz
 
         // restore font
         if (item.block == EASY_GLOBALS.selected_block)
-            _painter->setFont(ITEMS_FONT);
+            _painter->setFont(EASY_GLOBALS.items_font);
         // END Draw text~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
         if (do_paint_children)
@@ -458,7 +456,7 @@ void EasyGraphicsItem::paint(QPainter* _painter, const QStyleOptionGraphicsItem*
     EasyPainterInformation p(view());
 
     _painter->save();
-    _painter->setFont(ITEMS_FONT);
+    _painter->setFont(EASY_GLOBALS.items_font);
     
     // Reset indices of first visible item for each layer
     const auto levelsNumber = levels();
@@ -837,7 +835,7 @@ void EasyGraphicsItem::paint(QPainter* _painter, const QStyleOptionGraphicsItem*
                 _painter->setPen(p.textColor);
 
                 if (item.block == EASY_GLOBALS.selected_block)
-                    _painter->setFont(SELECTED_ITEM_FONT);
+                    _painter->setFont(EASY_GLOBALS.selected_item_font);
 
                 // drawing text
                 auto name = *itemBlock.tree.node->name() != 0 ? itemBlock.tree.node->name() : itemDesc.name();
@@ -855,7 +853,7 @@ void EasyGraphicsItem::paint(QPainter* _painter, const QStyleOptionGraphicsItem*
 
                 // restore font
                 if (item.block == EASY_GLOBALS.selected_block)
-                    _painter->setFont(ITEMS_FONT);
+                    _painter->setFont(EASY_GLOBALS.items_font);
                 // END Draw text~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 #ifdef EASY_GRAPHICS_ITEM_RECURSIVE_PAINT
@@ -944,7 +942,7 @@ void EasyGraphicsItem::paint(QPainter* _painter, const QStyleOptionGraphicsItem*
                             p.textColor = ::profiler_gui::textColorForRgb(itemDesc.color());// SELECTED_ITEM_COLOR);
                             _painter->setPen(p.textColor);
 
-                            _painter->setFont(SELECTED_ITEM_FONT);
+                            _painter->setFont(EASY_GLOBALS.selected_item_font);
 
                             // drawing text
                             auto name = *itemBlock.tree.node->name() != 0 ? itemBlock.tree.node->name() : itemDesc.name();

--- a/profiler_gui/globals.cpp
+++ b/profiler_gui/globals.cpp
@@ -104,6 +104,10 @@ namespace profiler_gui {
         , auto_adjust_histogram_height(true)
         , display_only_frames_on_histogram(false)
         , bind_scene_and_tree_expand_status(true)
+        , bg_font(::profiler_gui::EFont("Helvetica", 10, QFont::Bold))
+        , chronometer_font(::profiler_gui::EFont("Helvetica", 16, QFont::Bold))
+        , items_font(::profiler_gui::EFont("Helvetica", 10, QFont::Medium))
+        , selected_item_font(::profiler_gui::EFont("Helvetica", 10, QFont::Medium))
     {
 
     }

--- a/profiler_gui/globals.h
+++ b/profiler_gui/globals.h
@@ -60,6 +60,7 @@
 #include <QColor>
 #include <QTextCodec>
 #include <QSize>
+#include <QFont>
 #include "common_types.h"
 #include "globals_qobjects.h"
 
@@ -202,7 +203,10 @@ namespace profiler_gui {
         bool            display_only_frames_on_histogram; ///< Display only top-level blocks on histogram when drawing histogram by block id
         bool           bind_scene_and_tree_expand_status; /** \brief If true then items on graphics scene and in the tree (blocks hierarchy) are binded on each other
                                                                 so expanding/collapsing items on scene also expands/collapse items in the tree. */
-
+        QFont                                    bg_font; ///< Font for blocks_graphics_view
+        QFont                           chronometer_font; ///< Font for easy_chronometer_item
+        QFont                                 items_font; ///< Font for easy_graphics_item
+        QFont                         selected_item_font; ///< Font for easy_graphics_item
     private:
 
         EasyGlobals();
@@ -214,7 +218,7 @@ namespace profiler_gui {
 } // END of namespace profiler_gui.
 
 #ifndef IGNORE_GLOBALS_DECLARATION
-static ::profiler_gui::EasyGlobals& EASY_GLOBALS = ::profiler_gui::EasyGlobals::instance();
+#define EASY_GLOBALS ::profiler_gui::EasyGlobals::instance()
 
 inline ::profiler_gui::EasyBlock& easyBlock(::profiler::block_index_t i) {
     return EASY_GLOBALS.gui_blocks[i];

--- a/profiler_gui/main.cpp
+++ b/profiler_gui/main.cpp
@@ -50,8 +50,13 @@
 
 #include <chrono>
 #include <QApplication>
+#include <QFontDatabase>
+#include <QImageReader>
+#include <iostream>
+#include <QtPlugin>
 
 #include "main_window.h"
+#include "globals.h"
 
 #include <easy/reader.h>
 
@@ -64,25 +69,8 @@ int main(int argc, char **argv)
 {
     QApplication app(argc, argv);
 
-    //QFileSystemModel *model = new QFileSystemModel;
-    //model->setRootPath(QDir::currentPath());
-//     const char* filename = 0;
-//     if(argc > 1 && argv[1]){
-//         filename = argv[1];
-//     }else{
-//         return 255;
-//     }
-
-//     QFile file(filename);
-//     file.open(QIODevice::ReadOnly);
-//     TreeModel model(file.readAll());
-//     file.close();
-
-
-//     QTreeView *tree = new QTreeView();
-//     tree->setModel(&model);
-// 
-//     tree->show();
+    //Instanciate easy globals after QApplication to allow creation of global fonts, and on the main thread to avoid data races
+    EASY_GLOBALS;
 
     auto now = ::std::chrono::duration_cast<std::chrono::seconds>(::std::chrono::system_clock::now().time_since_epoch()).count() >> 1;
     srand((unsigned int)now);


### PR DESCRIPTION
This commit fixes #54. Important things to note are 

EASY_GLOBALS is now a macro (sorry). In the current design EASY_GLOBALS was still instantiated before QApplication so this didn't fix the bug.

The first call to EASY_GLOBALS is now directly after QApplication. This should prevent data races for vs2013 users.