### PR TITLE
Added several functions which can be used to query the state of any c…

### DIFF
--- a/easy_profiler_core/include/easy/profiler.h
+++ b/easy_profiler_core/include/easy/profiler.h
@@ -776,6 +776,14 @@ namespace profiler {
         PROFILER_API void stopListen();
         PROFILER_API bool isListening();
 
+        PROFILER_API bool hasConnection();
+        PROFILER_API void waitForConnection();
+        PROFILER_API void waitForConnectionEnd();
+
+        PROFILER_API bool hasCapture();
+        PROFILER_API void waitForCapture();
+        PROFILER_API void waitForCaptureEnd();
+
         /** Returns current major version.
         
         \ingroup profiler
@@ -881,6 +889,12 @@ namespace profiler {
     inline void startListen(uint16_t = ::profiler::DEFAULT_PORT) { }
     inline void stopListen() { }
     inline bool isListening() { return false; }
+    inline bool hasConnection() { return false; }
+    inline void waitForConnection() { }
+    inline void waitForConnectionEnd() { }
+    inline bool hasCapture() { return false; }
+    inline void waitForCapture() { }
+    inline void waitForCaptureEnd() { }
     inline uint8_t versionMajor() { return 0; }
     inline uint8_t versionMinor() { return 0; }
     inline uint16_t versionPatch() { return 0; }

--- a/easy_profiler_core/profile_manager.h
+++ b/easy_profiler_core/profile_manager.h
@@ -515,6 +515,8 @@ class ProfileManager
     std::atomic_bool             m_isAlreadyListening;
     std::atomic_bool                  m_frameMaxReset;
     std::atomic_bool                  m_frameAvgReset;
+    std::atomic_bool                        m_hasConn;
+    std::atomic_bool                     m_hasCapture;
 
     std::string m_csInfoFilename = "/tmp/cs_profiling_info.log";
 
@@ -571,6 +573,14 @@ public:
     void startListen(uint16_t _port);
     void stopListen();
     bool isListening() const;
+
+    bool hasConnection() const;
+    void waitForConnection() const;
+    void waitForConnectionEnd() const;
+
+    bool hasCapture() const;
+    void waitForCapture() const;
+    void waitForCaptureEnd() const;
 
 private:
 


### PR DESCRIPTION
…urrent connections to the profiler.

These changes have several usages throughout my code base, and I think they might be useful to others.

1. Early on app startup, we can optionally pass in a command line to wait for a connection or a capture, which allows us to analyse data from initialisation.

2. The perf tests in our unit test framework can optionally wait for a capture to begin, so we can analyse the results.

Usage is as follows:

```
    ::profiler::waitForCapture();

    ... normal execution

    ::profiler::waitForCaptureEnd();
```

Room for improvement:

1. Depending on your target audience, it may be appropriate to insert an `std::this_thread::sleep_for(std::chrono::milliseconds(1))` in the busy wait loop. For my usage this isn't necessary, but making the change is easy.

2. If you don't like the idea of having the `waitFor` functions in the easy_profiler core, I can remove them and we can defer them to user code. The only essential part of this change are the `hasConnection()` and `hasCapture()`. However, I included the `waitFor` functions because I believe that it is a very convenient addition to the API.

3. Connection end actually happens on 'easy profiler close' rather than 'halt the connection in easy profiler GUI'. I suspect this is because the easy profiler GUI keeps the socket open even after disconnecting. It isn't a big deal for my usage so I haven't touched it.