### PR TITLE
Fixed Issue #50 and Issue #61, added opt-in unaligned access support, and some documentation. 

### DIFF
--- a/easy_profiler_core/CMakeLists.txt
+++ b/easy_profiler_core/CMakeLists.txt
@@ -115,7 +115,7 @@ easy_define_target_option(easy_profiler EASY_OPTION_LOG EASY_OPTION_LOG_ENABLED)
 easy_define_target_option(easy_profiler EASY_OPTION_PREDEFINED_COLORS EASY_OPTION_BUILTIN_COLORS)
 
 if (UNIX)
-    target_compile_options(easy_profiler PRIVATE -Wall -Wno-long-long -Wno-reorder -Wno-braced-scalar-init -pedantic -O3)
+    target_compile_options(easy_profiler PRIVATE -Wall -Wno-long-long -Wno-reorder -Wno-braced-scalar-init -pedantic)
     target_link_libraries(easy_profiler pthread)
 elseif (WIN32)
     target_compile_definitions(easy_profiler PRIVATE -D_WIN32_WINNT=0x0600 -D_CRT_SECURE_NO_WARNINGS -D_WINSOCK_DEPRECATED_NO_WARNINGS)

--- a/easy_profiler_core/event_trace_win.cpp
+++ b/easy_profiler_core/event_trace_win.cpp
@@ -407,7 +407,7 @@ namespace profiler {
                         p.base = m_properties.base; // Use copy of m_properties to make sure m_properties will not be changed
 
                         // Stop another session
-                        ControlTrace(NULL, KERNEL_LOGGER_NAME, reinterpret_cast<EVENT_TRACE_PROPERTIES*>(&p), EVENT_TRACE_CONTROL_STOP);
+                        ControlTrace((TRACEHANDLE)NULL, KERNEL_LOGGER_NAME, reinterpret_cast<EVENT_TRACE_PROPERTIES*>(&p), EVENT_TRACE_CONTROL_STOP);
 
                         // Console window variant:
                         //if (32 >= (int)ShellExecute(NULL, NULL, "logman", "stop \"" KERNEL_LOGGER_NAME "\" -ets", NULL, SW_HIDE))

--- a/easy_profiler_core/include/easy/easy_compiler_support.h
+++ b/easy_profiler_core/include/easy/easy_compiler_support.h
@@ -82,6 +82,8 @@
                                                 VarName = VarInitializer
 # endif
 
+#define EASY_FORCE_INLINE __forceinline
+
 #elif defined (__clang__)
 //////////////////////////////////////////////////////////////////////////
 // Clang Compiler
@@ -101,6 +103,8 @@
 // There is no support for C++11 final keyword prior to clang 2.9
 #  define EASY_FINAL 
 # endif
+
+#define EASY_FORCE_INLINE inline __attribute__((always_inline))
 
 #elif defined(__GNUC__)
 //////////////////////////////////////////////////////////////////////////
@@ -124,6 +128,8 @@
 #  define EASY_FINAL 
 # endif
 
+#define EASY_FORCE_INLINE inline __attribute__((always_inline))
+
 #endif
 // END // TODO: Add other compilers support
 //////////////////////////////////////////////////////////////////////////
@@ -145,6 +151,10 @@
 
 #ifndef EASY_FINAL
 # define EASY_FINAL final
+#endif
+
+#ifndef EASY_FORCE_INLINE
+# define EASY_FORCE_INLINE inline
 #endif
 
 #ifndef PROFILER_API

--- a/easy_profiler_core/profile_manager.cpp
+++ b/easy_profiler_core/profile_manager.cpp
@@ -531,7 +531,7 @@ extern "C" {
 SerializedBlock::SerializedBlock(const Block& block, uint16_t name_length)
     : BaseBlockData(block)
 {
-    auto pName = const_cast<char*>(name());
+    char* pName = const_cast<char*>(name());
     if (name_length) strncpy(pName, block.name(), name_length);
     pName[name_length] = 0;
 }
@@ -539,7 +539,7 @@ SerializedBlock::SerializedBlock(const Block& block, uint16_t name_length)
 SerializedCSwitch::SerializedCSwitch(const CSwitchBlock& block, uint16_t name_length)
     : CSwitchEvent(block)
 {
-    auto pName = const_cast<char*>(name());
+    char* pName = const_cast<char*>(name());
     if (name_length) strncpy(pName, block.name(), name_length);
     pName[name_length] = 0;
 }
@@ -678,15 +678,15 @@ void ThreadStorage::storeBlock(const profiler::Block& block)
     EASY_THREAD_LOCAL static profiler::timestamp_t endTime = 0ULL;
 #endif
 
-    auto name_length = static_cast<uint16_t>(strlen(block.name()));
-    auto size = static_cast<uint16_t>(sizeof(BaseBlockData) + name_length + 1);
+    uint16_t name_length = static_cast<uint16_t>(strlen(block.name()));
+    uint16_t size = static_cast<uint16_t>(sizeof(BaseBlockData) + name_length + 1);
 
 #if EASY_OPTION_MEASURE_STORAGE_EXPAND != 0
     const bool expanded = (desc->m_status & profiler::ON) && blocks.closedList.need_expand(size);
     if (expanded) beginTime = getCurrentTime();
 #endif
 
-    auto data = blocks.closedList.allocate(size);
+    char* data = (char*)blocks.closedList.allocate(size);
 
 #if EASY_OPTION_MEASURE_STORAGE_EXPAND != 0
     if (expanded) endTime = getCurrentTime();

--- a/easy_profiler_core/profile_manager.cpp
+++ b/easy_profiler_core/profile_manager.cpp
@@ -711,9 +711,9 @@ void ThreadStorage::storeBlock(const profiler::Block& block)
 
 void ThreadStorage::storeCSwitch(const CSwitchBlock& block)
 {
-    auto name_length = static_cast<uint16_t>(strlen(block.name()));
-    auto size = static_cast<uint16_t>(sizeof(CSwitchEvent) + name_length + 1);
-    auto data = sync.closedList.allocate(size);
+    uint16_t name_length = static_cast<uint16_t>(strlen(block.name()));
+    uint16_t size = static_cast<uint16_t>(sizeof(CSwitchEvent) + name_length + 1);
+    void* data = sync.closedList.allocate(size);
     ::new (data) SerializedCSwitch(block, name_length);
     sync.usedMemorySize += size;
 }

--- a/easy_profiler_core/profile_manager.h
+++ b/easy_profiler_core/profile_manager.h
@@ -451,7 +451,7 @@ public:
         {
             // Temp to avoid extra load due to this* aliasing.
             uint16_t chunkOffset = m_chunkOffset;
-            char* data = (char*)&m_chunks.back().data[0] + chunkOffset;
+            char* data = (char*)m_chunks.back().data + chunkOffset;
             chunkOffset += n + sizeof(uint16_t);
             m_chunkOffset = chunkOffset;
 
@@ -523,14 +523,13 @@ public:
         // The maximum chunk offset is N-sizeof(uint16_t) b/c, if we hit that (or go past),
         // there is either no space left, 1 byte left, or 2 bytes left, all of which are
         // too small to cary more than a zero-sized element.
-        constexpr int_fast32_t MAX_CHUNK_OFFSET = (int_fast32_t)N-sizeof(uint16_t);
 
         chunk* current = m_chunks.last;
         do {
             const char* data = (char*)current->data;
             int_fast32_t chunkOffset = 0; // signed int so overflow is not checked.
             uint16_t payloadSize = unaligned_load16<uint16_t>(data);
-            while ((chunkOffset < MAX_CHUNK_OFFSET) & (payloadSize != 0)) {
+            while ((chunkOffset < (N-sizeof(uint16_t))) & (payloadSize != 0)) {
                 const uint16_t chunkSize = sizeof(uint16_t) + payloadSize;
                 _outputStream.write(data, chunkSize);
                 data += chunkSize;

--- a/easy_profiler_core/profile_manager.h
+++ b/easy_profiler_core/profile_manager.h
@@ -56,6 +56,7 @@ The Apache License, Version 2.0 (the "License");
 #include <thread>
 #include <atomic>
 #include <list>
+#include <cstring>
 
 //////////////////////////////////////////////////////////////////////////
 
@@ -177,7 +178,7 @@ class chunk_allocator
             auto prev = last;
             last = ::new (EASY_MALLOC(sizeof(chunk), EASY_ALIGNMENT_SIZE)) chunk();
             last->prev = prev;
-            *(uint16_t*)last->data = 0;
+            std::memset(last->data, 0, sizeof(uint16_t));
         }
 
         /** Invert current chunks list to enable to iterate over chunks list in direct order.

--- a/easy_profiler_core/profile_manager.h
+++ b/easy_profiler_core/profile_manager.h
@@ -146,10 +146,6 @@ namespace profiler {
 # endif
 #endif
 
-
-template <typename T>
-struct False : std::false_type {};
-
 //! Checks if a pointer is aligned.
 //! \param ptr The pointer to check.
 //! \param alignment The alignement (must be a power of 2)

--- a/easy_profiler_core/profile_manager.h
+++ b/easy_profiler_core/profile_manager.h
@@ -466,9 +466,7 @@ public:
             return data;
         }
 
-        // Temp to avoid extra load due to this* aliasing.
-        uint16_t chunkOffset = n + sizeof(uint16_t);
-        m_chunkOffset = chunkOffset;
+        m_chunkOffset = n + sizeof(uint16_t);
         m_chunks.emplace_back();
 
         char* data = (char*)&m_chunks.back().data[0];

--- a/easy_profiler_core/profile_manager.h
+++ b/easy_profiler_core/profile_manager.h
@@ -159,7 +159,7 @@ template <uint32_t ALIGNMENT>
 EASY_FORCE_INLINE bool is_aligned(void* ptr)
 {
     static_assert(ALIGNMENT % 2 == 0, "Alignment must be a power of two.");
-    return (uintptr_t)ptr & (ALIGNMENT-1) == 0;
+    return ((uintptr_t)ptr & (ALIGNMENT-1)) == 0;
 }
 
 EASY_FORCE_INLINE void unaligned_zero16(void* ptr)
@@ -213,7 +213,7 @@ EASY_FORCE_INLINE void unaligned_store16(void* ptr, T val)
 #ifndef EASY_ENABLE_STRICT_ALIGNMENT
     *(T*)ptr = val;
 #else
-    const char* const temp = &val;
+    const char* const temp = (char*)&val;
     ((char*)ptr)[0] = temp[0];
     ((char*)ptr)[1] = temp[1];
 #endif
@@ -226,7 +226,7 @@ EASY_FORCE_INLINE void unaligned_store32(void* ptr, T val)
 #ifndef EASY_ENABLE_STRICT_ALIGNMENT
     *(T*)ptr = val;
 #else
-    const char* const temp = &val;
+    const char* const temp = (char*)&val;
     ((char*)ptr)[0] = temp[0];
     ((char*)ptr)[1] = temp[1];
     ((char*)ptr)[2] = temp[2];
@@ -241,7 +241,7 @@ EASY_FORCE_INLINE void unaligned_store64(void* ptr, T val)
 #ifndef EASY_ENABLE_STRICT_ALIGNMENT
     *(T*)ptr = val;
 #else
-    const char* const temp = &val;
+    const char* const temp = (char*)&val;
     // Assume unaligned is more common.
     if (!is_aligned<alignof(T)>(ptr)) {
         ((char*)ptr)[0] = temp[0];

--- a/easy_profiler_core/profile_manager.h
+++ b/easy_profiler_core/profile_manager.h
@@ -427,6 +427,9 @@ class chunk_allocator
 
     //typedef std::list<chunk> chunk_list;
 
+    // Used in serialize(): workaround for no constexpr support in MSVC 2013.
+    static const int_fast32_t MAX_CHUNK_OFFSET = N-sizeof(uint16_t);
+
     chunk_list      m_chunks; ///< List of chunks.
     uint32_t          m_size; ///< Number of elements stored(# of times allocate() has been called.)
     uint16_t   m_chunkOffset; ///< Number of bytes used in the current chunk.
@@ -529,7 +532,7 @@ public:
             const char* data = (char*)current->data;
             int_fast32_t chunkOffset = 0; // signed int so overflow is not checked.
             uint16_t payloadSize = unaligned_load16<uint16_t>(data);
-            while ((chunkOffset < (N-sizeof(uint16_t))) & (payloadSize != 0)) {
+            while ((chunkOffset < MAX_CHUNK_OFFSET) & (payloadSize != 0)) {
                 const uint16_t chunkSize = sizeof(uint16_t) + payloadSize;
                 _outputStream.write(data, chunkSize);
                 data += chunkSize;


### PR DESCRIPTION
The main change here is ARMv5 support. On platforms like those that don't support unaligned access, code in the `chunk_allocator` was liable to break. I had originally thought that switching to `std::memset` and `std::memcpy` would have been fine, but after examining the assembly output, those calls weren't being optimized out, so I added some template functions for doing unaligned access that should optimize out to the same code as before if you don't enable strict alignment. To go along with this, I have added a force inline macro, `EASY_FORCE_INLINE` to the compiler support header.

I also fixed a MinGW warning, fixed issue #61, added some documentation, and potentially sped things up a bit. These changes need to be tested with MSVC in case I introduced warnings in the `serialize()` function, or somehow broke the code in some other way.