### PR TITLE
Fixed Issue #73. Added #include <malloc.h> to fix EASY_ENABLE_ALIGNMENT build error

### DIFF
--- a/easy_profiler_core/chunk_allocator.h
+++ b/easy_profiler_core/chunk_allocator.h
@@ -64,6 +64,8 @@ The Apache License, Version 2.0 (the "License");
 # define EASY_MALLOC(MEMSIZE, A) malloc(MEMSIZE)
 # define EASY_FREE(MEMPTR) free(MEMPTR)
 #else
+// MSVC and GNUC aligned versions of malloc are defined in malloc.h
+# include <malloc.h>
 # if defined(_MSC_VER)
 #  define EASY_ALIGNED(TYPE, VAR, A) __declspec(align(A)) TYPE VAR
 #  define EASY_MALLOC(MEMSIZE, A) _aligned_malloc(MEMSIZE, A)


### PR DESCRIPTION
Added a necessary include to fix builds with `-DEASY_ENABLE_ALIGNMENT`.