### PR TITLE
README: cmake build: added line to set include directory to yse

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ find_package(easy_profiler REQUIRED)
 
 add_executable(app_for_profiling ${SOURCES})
 
+target_include_directories(app_for_profiling $<TARGET_PROPERTY:easy_profiler,INTERFACE_INCLUDE_DIRECTORIES>)
 target_link_libraries(app_for_profiling easy_profiler)
 ```
 


### PR DESCRIPTION
Using the generated config file for easy_profiler we can use the target property for the include directory to add it to the executable in question.