### PR TITLE
Add support for building with Apple LLVM clang version < 8.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12.1)
+cmake_minimum_required(VERSION 3.0)
 project(easy_profiler CXX)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)

--- a/easy_profiler_core/CMakeLists.txt
+++ b/easy_profiler_core/CMakeLists.txt
@@ -6,21 +6,24 @@ message(STATUS "")
 
 #####################################################################
 # Checking c++11 thread_local support
-
 if (NOT WIN32)
     if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.8")
-            set(CXX11_THREAD_LOCAL_SUPPORT OFF)
+            set(NO_CXX11_THREAD_LOCAL_SUPPORT TRUE)
         endif ()
     elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "3.3")
-            set(NOT CXX11_THREAD_LOCAL_SUPPORT OFF)
+            set(NO_CXX11_THREAD_LOCAL_SUPPORT TRUE)
+        endif ()
+    elseif (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+        if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "8.0")
+            set(NO_CXX11_THREAD_LOCAL_SUPPORT TRUE)
         endif ()
     endif ()
     
     # TODO: Check thread_local keyword support for other compilers for Unix
     
-    if (NOT CXX11_THREAD_LOCAL_SUPPORT)
+    if (NO_CXX11_THREAD_LOCAL_SUPPORT)
         message(WARNING "  Your compiler does not support C++11 thread_local feature.")
         message(WARNING "  Without C++11 thread_local feature you may face to possible memory leak or application crash if using implicit thread registration and using EASY_THREAD instead of EASY_THREAD_SCOPE.")
     endif ()
@@ -44,7 +47,7 @@ if (WIN32)
     set(EASY_OPTION_EVENT_TRACING                ON CACHE BOOL "Enable event tracing by default")
     set(EASY_OPTION_LOW_PRIORITY_EVENT_TRACING   ON CACHE BOOL "Set low priority for event tracing thread")
 else ()
-    if (NOT CXX11_THREAD_LOCAL_SUPPORT)
+    if (NO_CXX11_THREAD_LOCAL_SUPPORT)
         set(EASY_OPTION_IMPLICIT_THREAD_REGISTRATION OFF CACHE BOOL ${EASY_OPTION_IMPLICIT_THREAD_REGISTER_TEXT})
         set(EASY_OPTION_REMOVE_EMPTY_UNGUARDED_THREADS OFF CACHE BOOL "Enable easy_profiler to remove empty unguarded threads. This fixes potential memory leak on Unix systems, but may lead to an application crash! This is used when C++11 thread_local is unavailable.")
     else ()
@@ -81,7 +84,7 @@ message(STATUS "  Implicit thread registration = ${EASY_OPTION_IMPLICIT_THREAD_R
 if (WIN32)
     message(STATUS "  Event tracing = ${EASY_OPTION_EVENT_TRACING}")
     message(STATUS "  Event tracing has low priority = ${EASY_OPTION_LOW_PRIORITY_EVENT_TRACING}")
-elseif (NOT CXX11_THREAD_LOCAL_SUPPORT)
+elseif (NO_CXX11_THREAD_LOCAL_SUPPORT)
     if (EASY_OPTION_IMPLICIT_THREAD_REGISTRATION)
         message(STATUS "    WARNING! Implicit thread registration for Unix systems can lead to memory leak")
         message(STATUS "             because there is no possibility to check if thread is alive and remove dead threads.")
@@ -175,7 +178,6 @@ target_compile_definitions(easy_profiler PUBLIC
 
 
 
-
 #####################################################################
 # Add EasyProfiler options definitions:
 easy_define_target_option(easy_profiler BUILD_WITH_CHRONO_STEADY_CLOCK EASY_CHRONO_STEADY_CLOCK)
@@ -192,8 +194,6 @@ else ()
 endif ()
 easy_define_target_option(easy_profiler EASY_OPTION_LOG EASY_OPTION_LOG_ENABLED)
 easy_define_target_option(easy_profiler EASY_OPTION_PREDEFINED_COLORS EASY_OPTION_BUILTIN_COLORS)
-easy_define_target_option(easy_profiler CXX11_THREAD_LOCAL_SUPPORT EASY_OPTION_THREAD_LOCAL_SUPPORT_ENABLED)
-
 # End adding EasyProfiler options definitions.
 #####################################################################
 

--- a/easy_profiler_core/CMakeLists.txt
+++ b/easy_profiler_core/CMakeLists.txt
@@ -6,20 +6,21 @@ message(STATUS "")
 
 #####################################################################
 # Checking c++11 thread_local support
+
 if (NOT WIN32)
     if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.8")
-            set(NO_CXX11_THREAD_LOCAL_SUPPORT TRUE)
+            set(CXX11_THREAD_LOCAL_SUPPORT OFF)
         endif ()
     elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "3.3")
-            set(NO_CXX11_THREAD_LOCAL_SUPPORT TRUE)
+            set(NOT CXX11_THREAD_LOCAL_SUPPORT OFF)
         endif ()
     endif ()
     
     # TODO: Check thread_local keyword support for other compilers for Unix
     
-    if (NO_CXX11_THREAD_LOCAL_SUPPORT)
+    if (NOT CXX11_THREAD_LOCAL_SUPPORT)
         message(WARNING "  Your compiler does not support C++11 thread_local feature.")
         message(WARNING "  Without C++11 thread_local feature you may face to possible memory leak or application crash if using implicit thread registration and using EASY_THREAD instead of EASY_THREAD_SCOPE.")
     endif ()
@@ -43,7 +44,7 @@ if (WIN32)
     set(EASY_OPTION_EVENT_TRACING                ON CACHE BOOL "Enable event tracing by default")
     set(EASY_OPTION_LOW_PRIORITY_EVENT_TRACING   ON CACHE BOOL "Set low priority for event tracing thread")
 else ()
-    if (NO_CXX11_THREAD_LOCAL_SUPPORT)
+    if (NOT CXX11_THREAD_LOCAL_SUPPORT)
         set(EASY_OPTION_IMPLICIT_THREAD_REGISTRATION OFF CACHE BOOL ${EASY_OPTION_IMPLICIT_THREAD_REGISTER_TEXT})
         set(EASY_OPTION_REMOVE_EMPTY_UNGUARDED_THREADS OFF CACHE BOOL "Enable easy_profiler to remove empty unguarded threads. This fixes potential memory leak on Unix systems, but may lead to an application crash! This is used when C++11 thread_local is unavailable.")
     else ()
@@ -80,7 +81,7 @@ message(STATUS "  Implicit thread registration = ${EASY_OPTION_IMPLICIT_THREAD_R
 if (WIN32)
     message(STATUS "  Event tracing = ${EASY_OPTION_EVENT_TRACING}")
     message(STATUS "  Event tracing has low priority = ${EASY_OPTION_LOW_PRIORITY_EVENT_TRACING}")
-elseif (NO_CXX11_THREAD_LOCAL_SUPPORT)
+elseif (NOT CXX11_THREAD_LOCAL_SUPPORT)
     if (EASY_OPTION_IMPLICIT_THREAD_REGISTRATION)
         message(STATUS "    WARNING! Implicit thread registration for Unix systems can lead to memory leak")
         message(STATUS "             because there is no possibility to check if thread is alive and remove dead threads.")
@@ -174,6 +175,7 @@ target_compile_definitions(easy_profiler PUBLIC
 
 
 
+
 #####################################################################
 # Add EasyProfiler options definitions:
 easy_define_target_option(easy_profiler BUILD_WITH_CHRONO_STEADY_CLOCK EASY_CHRONO_STEADY_CLOCK)
@@ -190,6 +192,8 @@ else ()
 endif ()
 easy_define_target_option(easy_profiler EASY_OPTION_LOG EASY_OPTION_LOG_ENABLED)
 easy_define_target_option(easy_profiler EASY_OPTION_PREDEFINED_COLORS EASY_OPTION_BUILTIN_COLORS)
+easy_define_target_option(easy_profiler CXX11_THREAD_LOCAL_SUPPORT EASY_OPTION_THREAD_LOCAL_SUPPORT_ENABLED)
+
 # End adding EasyProfiler options definitions.
 #####################################################################
 

--- a/easy_profiler_core/include/easy/easy_compiler_support.h
+++ b/easy_profiler_core/include/easy/easy_compiler_support.h
@@ -88,7 +88,7 @@
 //////////////////////////////////////////////////////////////////////////
 // Clang Compiler
 
-# if (__clang_major__ == 3 && __clang_minor__ < 3) || (__clang_major__ < 3)
+# if (EASY_OPTION_THREAD_LOCAL_SUPPORT_ENABLED == 0)
 // There is no support for C++11 thread_local keyword prior to clang 3.3. Use __thread instead.
 #  define EASY_THREAD_LOCAL __thread
 # endif
@@ -110,7 +110,7 @@
 //////////////////////////////////////////////////////////////////////////
 // GNU Compiler
 
-# if (__GNUC__ == 4 && __GNUC_MINOR__ < 8) || (__GNUC__ < 4)
+# if (EASY_OPTION_THREAD_LOCAL_SUPPORT_ENABLED == 0)
 // There is no support for C++11 thread_local keyword prior to gcc 4.8. Use __thread instead.
 #  define EASY_THREAD_LOCAL __thread
 # endif

--- a/easy_profiler_core/include/easy/easy_compiler_support.h
+++ b/easy_profiler_core/include/easy/easy_compiler_support.h
@@ -88,7 +88,7 @@
 //////////////////////////////////////////////////////////////////////////
 // Clang Compiler
 
-# if (EASY_OPTION_THREAD_LOCAL_SUPPORT_ENABLED == 0)
+# if (__clang_major__ == 3 && __clang_minor__ < 3) || (__clang_major__ < 3) || (defined __APPLE_CC__ && __APPLE_CC__ < 8000)
 // There is no support for C++11 thread_local keyword prior to clang 3.3. Use __thread instead.
 #  define EASY_THREAD_LOCAL __thread
 # endif
@@ -110,7 +110,7 @@
 //////////////////////////////////////////////////////////////////////////
 // GNU Compiler
 
-# if (EASY_OPTION_THREAD_LOCAL_SUPPORT_ENABLED == 0)
+# if (__GNUC__ == 4 && __GNUC_MINOR__ < 8) || (__GNUC__ < 4)
 // There is no support for C++11 thread_local keyword prior to gcc 4.8. Use __thread instead.
 #  define EASY_THREAD_LOCAL __thread
 # endif

--- a/easy_profiler_core/include/easy/easy_compiler_support.h
+++ b/easy_profiler_core/include/easy/easy_compiler_support.h
@@ -89,7 +89,7 @@
 // Clang Compiler
 
 # if (__clang_major__ == 3 && __clang_minor__ < 3) || (__clang_major__ < 3) || (defined __APPLE_CC__ && __APPLE_CC__ < 8000)
-// There is no support for C++11 thread_local keyword prior to clang 3.3. Use __thread instead.
+// There is no support for C++11 thread_local keyword prior to clang 3.3 and Apple LLVM clang 8.0. Use __thread instead.
 #  define EASY_THREAD_LOCAL __thread
 # endif
 

--- a/easy_profiler_core/nonscoped_block.cpp
+++ b/easy_profiler_core/nonscoped_block.cpp
@@ -41,7 +41,8 @@ The Apache License, Version 2.0 (the "License");
 **/
 
 #include "nonscoped_block.h"
-#include <string.h>
+#include <cstring>
+#include <cstdlib>
 
 NonscopedBlock::NonscopedBlock(const profiler::BaseBlockDescriptor* _desc, const char* _runtimeName, bool)
     : profiler::Block(_desc, _runtimeName, false), m_runtimeName(nullptr)

--- a/easy_profiler_core/stack_buffer.h
+++ b/easy_profiler_core/stack_buffer.h
@@ -46,6 +46,7 @@ The Apache License, Version 2.0 (the "License");
 #include "nonscoped_block.h"
 #include <list>
 #include <algorithm>
+#include <cstdlib>
 
 #ifdef max
 #undef max


### PR DESCRIPTION
Pre 2016 Apple clang was version >= 3.3 but did not contain support for C++11 thread_local. This change's purpose is to add support for building with non-latest Apple clang compiler as well via passing "cmake -DCXX11_THREAD_LOCAL_SUPPORT=OFF" option.