### PR TITLE
#0: various fixes for windows build

### DIFF
--- a/easy_profiler_core/block.cpp
+++ b/easy_profiler_core/block.cpp
@@ -51,7 +51,7 @@
 #include "profile_manager.h"
 #include "current_time.h"
 
-using namespace profiler;
+namespace profiler {
 
 #ifndef EASY_PROFILER_API_DISABLED
 Event::Event(timestamp_t _begin_time) : m_begin(_begin_time), m_end(0)
@@ -230,7 +230,9 @@ CSwitchEvent::CSwitchEvent(timestamp_t _begin_time, thread_id_t _tid)
 
 }
 
-CSwitchBlock::CSwitchBlock(timestamp_t _begin_time, thread_id_t _tid, const char* _runtimeName)
+} // END of namespace profiler.
+
+CSwitchBlock::CSwitchBlock(profiler::timestamp_t _begin_time, profiler::thread_id_t _tid, const char* _runtimeName)
     : CSwitchEvent(_begin_time, _tid)
     , m_name(_runtimeName)
 {

--- a/easy_profiler_core/easy_socket.cpp
+++ b/easy_profiler_core/easy_socket.cpp
@@ -106,13 +106,12 @@ int EasySocket::bind(uint16_t port)
     if (!checkSocket(m_socket))
         return -1;
 
-    struct sockaddr_in serv_addr;
-    memset(&serv_addr, 0, sizeof(serv_addr));
-    serv_addr.sin_family = AF_INET;
-    serv_addr.sin_addr.s_addr = INADDR_ANY;
-    serv_addr.sin_port = htons(port);
-    auto res = ::bind(m_socket, (struct sockaddr*)&serv_addr, sizeof(serv_addr));
-
+    struct sockaddr_in server_address;
+    memset(&server_address, 0, sizeof(server_address));
+    server_address.sin_family = AF_INET;
+    server_address.sin_addr.s_addr = INADDR_ANY;
+    server_address.sin_port = htons(port);
+    auto res = ::bind(m_socket, (struct sockaddr *)&server_address, sizeof(server_address));
     return res;
 }
 

--- a/easy_profiler_core/event_trace_win.cpp
+++ b/easy_profiler_core/event_trace_win.cpp
@@ -59,10 +59,6 @@
 #ifdef _WIN32
 #include <memory.h>
 #include <chrono>
-#if UNICODE
-#   include <codecvt>
-#   include <sstream>
-#endif
 #include <unordered_map>
 #include <easy/profiler.h>
 #include "profile_manager.h"
@@ -144,53 +140,13 @@ namespace profiler {
     const decltype(EVENT_DESCRIPTOR::Opcode) SWITCH_CONTEXT_OPCODE = 36;
     const int RAW_TIMESTAMP_TIME_TYPE = 1;
 
-    namespace {
+    //////////////////////////////////////////////////////////////////////////
 
-        //////////////////////////////////////////////////////////////////////////
-
-        class ProcessInfo {
-        public:
-            bool initialized() const;
-            void init(processid_t process_id);
-            void set_name(PTCHAR process_name);
-
-            const char* info_cstr() const
-            {
-                return name.c_str();
-            }
-
-        private:
-            std::string name;
-        };
-
-        bool ProcessInfo::initialized() const
-        {
-            return !name.empty();
-        }
-
-        void ProcessInfo::init(processid_t process_id)
-        {
-            if (initialized())
-                return;
-
-            std::stringstream ss;
-            ss << process_id;
-            name = ss.str();
-        }
-
-        void ProcessInfo::set_name(PTCHAR process_name)
-        {
-            name += " ";
-#if UNICODE
-            using ConvertType = std::codecvt_utf8<wchar_t>;
-            std::wstring_convert<ConvertType, wchar_t> converter;
-            name += converter.to_bytes(process_name);
-#else
-            name.append(process_name);
-#endif
-        }
-
-    }  // END of namespace unnamed.
+    struct ProcessInfo {
+        std::string      name;
+        processid_t    id = 0;
+        int8_t      valid = 0;
+    };
 
     //////////////////////////////////////////////////////////////////////////
 
@@ -258,9 +214,15 @@ namespace profiler {
                 pid = GetProcessIdOfThread(hThread);
                 auto pinfo = &PROCESS_INFO_TABLE[pid];
 
-                if (!pinfo->initialized())
+                if (pinfo->valid == 0)
                 {
-                    pinfo->init(pid);
+                    if (pinfo->name.empty())
+                    {
+                        static char numbuf[128] = {};
+                        sprintf(numbuf, "%u", pid);
+                        pinfo->name = numbuf;
+                        pinfo->id = pid;
+                    }
 
                     /*
                     According to documentation, using GetModuleBaseName() requires
@@ -279,7 +241,17 @@ namespace profiler {
                         auto len = GetModuleBaseName(hProc, 0, buf, MAX_PATH);
 
                         if (len != 0)
-                            pinfo->set_name(buf);
+                        {
+                            pinfo->name.reserve(pinfo->name.size() + 2 + len);
+                            pinfo->name.append(" ", 1);
+#if UNICODE
+                            std::wstring wbuf(buf);
+                            pinfo->name.append(std::string(wbuf.begin(), wbuf.end()), len);
+#else
+                            pinfo->name.append(buf, len);
+#endif
+                            pinfo->valid = 1;
+                        }
 
                         CloseHandle(hProc);
                     }
@@ -287,13 +259,16 @@ namespace profiler {
                     {
                         //auto err = GetLastError();
                         //printf("OpenProcess(%u) fail: GetLastError() == %u\n", pid, err);
+                        pinfo->valid = -1;
 
-                        if (pid == 4)
-                            pinfo->set_name(TEXT("System"));
+                        if (pid == 4) {
+                            pinfo->name.reserve(pinfo->name.size() + 8);
+                            pinfo->name.append(" System", 7);
+                        }
                     }
                 }
 
-                process_name = pinfo->info_cstr();
+                process_name = pinfo->name.c_str();
                 THREAD_PROCESS_INFO_TABLE[_contextSwitchEvent->NewThreadId] = pinfo;
 
                 CloseHandle(hThread);
@@ -308,7 +283,7 @@ namespace profiler {
         {
             auto pinfo = it->second;
             if (pinfo != nullptr)
-                process_name = pinfo->info_cstr();
+                process_name = pinfo->name.c_str();
             else if (it->first == 0)
                 process_name = "System Idle";
             else if (it->first == 4)
@@ -319,16 +294,16 @@ namespace profiler {
         MANAGER.endContextSwitch(_contextSwitchEvent->NewThreadId, pid, time);
     }
 
-    //////////////////////////////////////////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////
 
-    EasyEventTracer::Properties::Properties()
-    {
+	EasyEventTracer::Properties::Properties()
+	{
 #if UNICODE
-        std::wcstombs(sessionName, KERNEL_LOGGER_NAME, sizeof(sessionName));
+		std::wcstombs(sessionName, KERNEL_LOGGER_NAME, sizeof(sessionName));
 #else
-        strncpy(sessionName, KERNEL_LOGGER_NAME, sizeof(sessionName));
+		strncpy(sessionName, KERNEL_LOGGER_NAME, sizeof(prp.sessionName));
 #endif
-    }
+	}
 
     //////////////////////////////////////////////////////////////////////////
 

--- a/easy_profiler_core/event_trace_win.cpp
+++ b/easy_profiler_core/event_trace_win.cpp
@@ -150,18 +150,9 @@ namespace profiler {
 
         class ProcessInfo {
         public:
-            void set_id(processid_t process_id);
+            bool initialized() const;
+            void init(processid_t process_id);
             void set_name(PTCHAR process_name);
-
-            bool is_initialized() const
-            {
-                return initialized;
-            }
-
-            void set_initialized()
-            {
-                initialized = true;
-            }
 
             const char* info_cstr() const
             {
@@ -169,13 +160,17 @@ namespace profiler {
             }
 
         private:
-            bool initialized = false;
             std::string name;
         };
 
-        void ProcessInfo::set_id(processid_t process_id)
+        bool ProcessInfo::initialized() const
         {
-            if (!name.empty())
+            return !name.empty();
+        }
+
+        void ProcessInfo::init(processid_t process_id)
+        {
+            if (initialized())
                 return;
 
             std::stringstream ss;
@@ -263,9 +258,9 @@ namespace profiler {
                 pid = GetProcessIdOfThread(hThread);
                 auto pinfo = &PROCESS_INFO_TABLE[pid];
 
-                if (!pinfo->is_initialized())
+                if (!pinfo->initialized())
                 {
-                    pinfo->set_id(pid);
+                    pinfo->init(pid);
 
                     /*
                     According to documentation, using GetModuleBaseName() requires
@@ -284,10 +279,7 @@ namespace profiler {
                         auto len = GetModuleBaseName(hProc, 0, buf, MAX_PATH);
 
                         if (len != 0)
-                        {
                             pinfo->set_name(buf);
-                            pinfo->set_initialized();
-                        }
 
                         CloseHandle(hProc);
                     }
@@ -298,8 +290,6 @@ namespace profiler {
 
                         if (pid == 4)
                             pinfo->set_name(TEXT("System"));
-
-                        pinfo->set_initialized();
                     }
                 }
 

--- a/easy_profiler_core/event_trace_win.h
+++ b/easy_profiler_core/event_trace_win.h
@@ -81,6 +81,8 @@ namespace profiler {
 
 #pragma pack(push, 1)
         struct Properties {
+            Properties();
+
             EVENT_TRACE_PROPERTIES base;
             char sessionName[sizeof(KERNEL_LOGGER_NAME)];
         };

--- a/easy_profiler_core/profile_manager.cpp
+++ b/easy_profiler_core/profile_manager.cpp
@@ -763,6 +763,7 @@ const BaseBlockDescriptor* ProfileManager::addBlockDescriptor(EasyBlockStatus _d
     }
 #else
     auto desc = new BlockDescriptor(static_cast<block_id_t>(m_descriptors.size()), _defaultStatus, _name, _filename, _line, _block_type, _color);
+    (void)_copyName; // unused
 #endif
 
     m_descriptors.emplace_back(desc);
@@ -1178,7 +1179,7 @@ void ProfileManager::setEnabled(bool isEnable)
     guard_lock_t lock(m_dumpSpin);
 
     auto time = getCurrentTime();
-    const auto status = isEnable ? EASY_PROF_ENABLED : EASY_PROF_DISABLED;
+    const auto status = static_cast<char>(isEnable ? EASY_PROF_ENABLED : EASY_PROF_DISABLED);
     const auto prev = m_profilerStatus.exchange(status, std::memory_order_release);
     if (prev == status)
         return;

--- a/profiler_gui/blocks_tree_widget.cpp
+++ b/profiler_gui/blocks_tree_widget.cpp
@@ -795,7 +795,7 @@ void EasyTreeWidget::onCollapseAllClicked(bool)
 
 void EasyTreeWidget::onExpandAllClicked(bool)
 {
-    const QSignalBlocker b(this);
+    const QSignalBlocker blocker(this);
 
     m_bSilentExpandCollapse = true;
     expandAll();

--- a/profiler_gui/common_types.h
+++ b/profiler_gui/common_types.h
@@ -328,8 +328,6 @@ inline QString timeStringReal(TimeUnits _units, qreal _interval, int _precision 
         default:
             return autoTimeStringReal(_interval, _precision);
     }
-
-    return QString();
 }
 
 inline QString timeStringRealNs(TimeUnits _units, ::profiler::timestamp_t _interval, int _precision = 1)
@@ -351,8 +349,6 @@ inline QString timeStringRealNs(TimeUnits _units, ::profiler::timestamp_t _inter
         default:
             return autoTimeStringRealNs(_interval, _precision);
     }
-
-    return QString();
 }
 
 inline QString timeStringInt(TimeUnits _units, qreal _interval)
@@ -372,8 +368,6 @@ inline QString timeStringInt(TimeUnits _units, qreal _interval)
         default:
             return autoTimeStringInt(_interval);
     }
-
-    return QString();
 }
 
 inline QString timeStringIntNs(TimeUnits _units, ::profiler::timestamp_t _interval)
@@ -393,8 +387,6 @@ inline QString timeStringIntNs(TimeUnits _units, ::profiler::timestamp_t _interv
         default:
             return autoTimeStringIntNs(_interval);
     }
-
-    return QString();
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/profiler_gui/descriptors_tree_widget.cpp
+++ b/profiler_gui/descriptors_tree_widget.cpp
@@ -269,14 +269,14 @@ void EasyDescTreeWidget::contextMenuEvent(QContextMenuEvent* _event)
     connect(action, &QAction::triggered, this, &This::collapseAll);
 
     menu.addSeparator();
-    auto submenu = menu.addMenu("Search by");
+    auto searchby_submenu = menu.addMenu("Search by");
     auto header_item = headerItem();
     for (int i = 0; i < DESC_COL_STATUS; ++i)
     {
         if (i == DESC_COL_TYPE)
             continue;
 
-        action = submenu->addAction(header_item->text(i));
+        action = searchby_submenu->addAction(header_item->text(i));
         action->setData(i);
         action->setCheckable(true);
         if (i == m_searchColumn)
@@ -537,7 +537,7 @@ void EasyDescTreeWidget::onBlockStatusChangeClicked(bool _checked)
     }
 }
 
-void EasyDescTreeWidget::onBlockStatusChange(::profiler::block_id_t _id, ::profiler::EasyBlockStatus _status)
+void EasyDescTreeWidget::onBlockStatusChange(::profiler::block_id_t _id, ::profiler::EasyBlockStatus /* _status */)
 {
     if (m_bLocked)
         return;

--- a/profiler_gui/easy_graphics_scrollbar.cpp
+++ b/profiler_gui/easy_graphics_scrollbar.cpp
@@ -154,7 +154,7 @@ EasyGraphicsSliderItem::~EasyGraphicsSliderItem()
 
 }
 
-void EasyGraphicsSliderItem::paint(QPainter* _painter, const QStyleOptionGraphicsItem* _option, QWidget* _widget)
+void EasyGraphicsSliderItem::paint(QPainter* _painter, const QStyleOptionGraphicsItem* /* _option */, QWidget* /* _widget */)
 {
     if (static_cast<const EasyGraphicsScrollbar*>(scene()->parent())->bindMode())
     {
@@ -280,7 +280,7 @@ QRectF EasyHistogramItem::boundingRect() const
     return m_boundingRect;
 }
 
-void EasyHistogramItem::paint(QPainter* _painter, const QStyleOptionGraphicsItem* _option, QWidget* _widget)
+void EasyHistogramItem::paint(QPainter* _painter, const QStyleOptionGraphicsItem* /* _option */, QWidget* /* _widget */)
 {
     if (!m_bPermitImageUpdate || (m_regime == Hist_Pointer && m_pSource == nullptr) || (m_regime == Hist_Id && (m_threadId == 0 || ::profiler_gui::is_max(m_blockId))))
         return;
@@ -1401,7 +1401,7 @@ void EasyHistogramItem::updateImage(QRectF _boundingRect, HistRegime _regime, qr
                                     qreal _minimum, qreal _maximum, qreal _range,
                                     qreal _value, qreal _width, qreal _top_duration, qreal _bottom_duration,
                                     bool _bindMode, float _frame_time, ::profiler::timestamp_t _begin_time,
-                                    qreal _origin, bool _autoAdjustHist)
+                                    qreal /* _origin */, bool _autoAdjustHist)
 {
     const auto bottom = _boundingRect.height();//_boundingRect.bottom();
     const auto screenWidth = _boundingRect.width() * _current_scale;

--- a/profiler_gui/main_window.cpp
+++ b/profiler_gui/main_window.cpp
@@ -783,14 +783,14 @@ void EasyMainWindow::loadFile(const QString& filename)
     m_reader.load(filename);
 }
 
-void EasyMainWindow::readStream(::std::stringstream& data)
+void EasyMainWindow::readStream(::std::stringstream& _data)
 {
     m_progress->setLabelText(tr("Reading from stream..."));
 
     m_progress->setValue(0);
     m_progress->show();
     m_readerTimer.start(LOADER_TIMER_INTERVAL);
-    m_reader.load(data);
+    m_reader.load(_data);
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/profiler_gui/tree_widget_item.cpp
+++ b/profiler_gui/tree_widget_item.cpp
@@ -113,8 +113,6 @@ bool EasyTreeWidgetItem::operator < (const Parent& _other) const
             return data(col, Qt::UserRole).toULongLong() < _other.data(col, Qt::UserRole).toULongLong();
         }
     }
-
-    return false;
 }
 
 ::profiler::block_index_t EasyTreeWidgetItem::block_index() const


### PR DESCRIPTION
* remove warnings that definition of a variable hides previously defined ones
* remove warnings that function argument is not used
* remove warnings that statements are not reached
* event_trace_win: fix compilation with UNICODE