### PR TITLE
Fix Android build

### DIFF
--- a/easy_profiler_core/CMakeLists.txt
+++ b/easy_profiler_core/CMakeLists.txt
@@ -220,7 +220,9 @@ easy_define_target_option(easy_profiler EASY_OPTION_PREDEFINED_COLORS EASY_OPTIO
 # Add platform specific compile options:
 if (UNIX)
     target_compile_options(easy_profiler PRIVATE -Wall -Wno-long-long -Wno-reorder -Wno-braced-scalar-init -pedantic)
-    target_link_libraries(easy_profiler pthread)
+    if (!ANDROID)
+        target_link_libraries(easy_profiler pthread)
+    endif()
 elseif (WIN32)
     target_compile_definitions(easy_profiler PRIVATE -D_WIN32_WINNT=0x0600 -D_CRT_SECURE_NO_WARNINGS -D_WINSOCK_DEPRECATED_NO_WARNINGS)
     target_link_libraries(easy_profiler ws2_32 psapi)


### PR DESCRIPTION
Android does not have libpthread, but instead exposes the pthread functions via Bionic
See: https://android.googlesource.com/platform/bionic/+/10ce969/libc/bionic/pthread.c

This enables Android builds out of the box :)