### PR TITLE
EasySocket::accept() waits 500ms instead 0.5ms till select timeout.

### DIFF
--- a/easy_profiler_core/easy_socket.cpp
+++ b/easy_profiler_core/easy_socket.cpp
@@ -320,7 +320,7 @@ int EasySocket::accept()
     fd_set fdwrite = fdread;
     fd_set fdexcl = fdread;
 
-    struct timeval tv { 0, 500 };
+    struct timeval tv { 0, 500000 };
     const int rc = ::select((int)m_socket + 1, &fdread, &fdwrite, &fdexcl, &tv);
     if (rc <= 0)
         return -1; // there is no connection for accept


### PR DESCRIPTION
`EasySocket::accept()` waits 0.5ms till a `select()` timeout happens. This creates 2.7% overhead on my system. Assumption of the patch is that microseconds are needed for the `struct timeval` but milliseconds were meant. With this change no visible overhead is measurable on my system. 