### PR TITLE
keyword static should come before thread local qualifier

### DIFF
--- a/easy_profiler_core/current_thread.h
+++ b/easy_profiler_core/current_thread.h
@@ -75,10 +75,10 @@ inline profiler::thread_id_t getCurrentThreadId()
     return (profiler::thread_id_t)pthread_self();
 #   endif
 #elif defined(__QNX__)
-    EASY_THREAD_LOCAL static const profiler::thread_id_t _id = (profiler::thread_id_t)gettid();
+    static EASY_THREAD_LOCAL const profiler::thread_id_t _id = (profiler::thread_id_t)gettid();
     return _id;
 #else
-    EASY_THREAD_LOCAL static const profiler::thread_id_t _id = (profiler::thread_id_t)syscall(__NR_gettid);
+    static EASY_THREAD_LOCAL const profiler::thread_id_t _id = (profiler::thread_id_t)syscall(__NR_gettid);
     return _id;
 #endif
 }

--- a/easy_profiler_core/include/easy/profiler.h
+++ b/easy_profiler_core/include/easy/profiler.h
@@ -233,7 +233,7 @@ will end previously opened EASY_BLOCK or EASY_FUNCTION.
 \ingroup profiler
 */
 # define EASY_THREAD(name)\
-    EASY_THREAD_LOCAL static const char* EASY_TOKEN_CONCATENATE(unique_profiler_thread_name, __LINE__) = nullptr;\
+    static EASY_THREAD_LOCAL const char* EASY_TOKEN_CONCATENATE(unique_profiler_thread_name, __LINE__) = nullptr;\
     if (!EASY_TOKEN_CONCATENATE(unique_profiler_thread_name, __LINE__))\
         EASY_TOKEN_CONCATENATE(unique_profiler_thread_name, __LINE__) = ::profiler::registerThread(name);
 

--- a/easy_profiler_core/thread_storage.cpp
+++ b/easy_profiler_core/thread_storage.cpp
@@ -127,8 +127,8 @@ void ThreadStorage::storeBlock(const profiler::Block& block)
                           MANAGER.addBlockDescriptor(EASY_OPTION_STORAGE_EXPAND_BLOCKS_ON ? profiler::ON : profiler::OFF, EASY_UNIQUE_LINE_ID, "EasyProfiler.ExpandStorage", \
                                                      __FILE__, __LINE__, profiler::BlockType::Block, EASY_COLOR_INTERNAL_EVENT));
 
-    EASY_THREAD_LOCAL static profiler::timestamp_t beginTime = 0ULL;
-    EASY_THREAD_LOCAL static profiler::timestamp_t endTime = 0ULL;
+    static EASY_THREAD_LOCAL profiler::timestamp_t beginTime = 0ULL;
+    static EASY_THREAD_LOCAL profiler::timestamp_t endTime = 0ULL;
 #endif
 
 #if EASY_OPTION_TRUNCATE_LONG_RUNTIME_NAMES != 0


### PR DESCRIPTION
static should come before __thread etc. This causes warnings with clang when using e.g. EASY_THREAD: 

warning: '__thread' before 'static' [-Wpedantic]

It seems this was partially addressed with [53289ce](https://github.com/yse/easy_profiler/commit/53289cec812fc61b1851c16fe38f3dbd3993ea8f) but some instances were missed. 