### PR TITLE
CMake: fix install target for bundles (iOS/tvOS/watchOS)

### DIFF
--- a/easy_profiler_converter/CMakeLists.txt
+++ b/easy_profiler_converter/CMakeLists.txt
@@ -15,7 +15,6 @@ target_link_libraries(profiler_converter easy_profiler)
 install(
     TARGETS
     profiler_converter
-    RUNTIME
     DESTINATION
     bin
 )

--- a/profiler_gui/CMakeLists.txt
+++ b/profiler_gui/CMakeLists.txt
@@ -81,7 +81,6 @@ if (Qt5Widgets_FOUND)
     install(
         TARGETS
         profiler_gui
-        RUNTIME
         DESTINATION
         bin
     )


### PR DESCRIPTION
executables in install target need a BUNDLE DESTINATION if cross-build to iOS/tvOS/watchOS

By removing `RUNTIME`, the same `DESTINATION` is set for all types, including `BUNDLE` (and since there are only executables in those install commands, we don't care of `ARCHIVE` and `LIBRARY` destination).

see https://cmake.org/cmake/help/latest/policy/CMP0006.html (and `MACOSX_BUNDLE` is ON by default for iOS/tvOS/watchOS: https://cmake.org/cmake/help/latest/variable/CMAKE_MACOSX_BUNDLE.html#variable:CMAKE_MACOSX_BUNDLE)