### PR TITLE
Fix EMSCRIPTEN build

### DIFF
--- a/easy_profiler_core/current_thread.h
+++ b/easy_profiler_core/current_thread.h
@@ -77,6 +77,9 @@ inline profiler::thread_id_t getCurrentThreadId()
 #elif defined(__QNX__)
     EASY_THREAD_LOCAL static const profiler::thread_id_t _id = (profiler::thread_id_t)gettid();
     return _id;
+#elif defined(__EMSCRIPTEN__)
+    EASY_THREAD_LOCAL static const profiler::thread_id_t _id = static_cast<profiler::thread_id_t>(pthread_self());
+    return _id;
 #else
     EASY_THREAD_LOCAL static const profiler::thread_id_t _id = (profiler::thread_id_t)syscall(__NR_gettid);
     return _id;

--- a/easy_profiler_core/include/easy/easy_socket.h
+++ b/easy_profiler_core/include/easy/easy_socket.h
@@ -59,7 +59,9 @@ The Apache License, Version 2.0 (the "License");
 #else
 
 // Windows
-# define WIN32_LEAN_AND_MEAN
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
 # include <winsock2.h>
 # include <windows.h>
 # include <ws2tcpip.h>

--- a/easy_profiler_core/include/easy/serialized_block.h
+++ b/easy_profiler_core/include/easy/serialized_block.h
@@ -91,7 +91,6 @@ namespace profiler {
 
     public:
 
-        CSwitchEvent() = default;
         CSwitchEvent(const CSwitchEvent&) = default;
         explicit CSwitchEvent(timestamp_t _begin_time, thread_id_t _tid) EASY_NOEXCEPT;
 
@@ -129,7 +128,7 @@ namespace profiler {
 #pragma pack(push, 1)
     class PROFILER_API SerializedBlockDescriptor EASY_FINAL : public BaseBlockDescriptor
     {
-        uint16_t m_nameLength; ///< Length of the name including trailing '\0' sybmol
+        uint16_t m_nameLength; ///< Length of the name including trailing '\0' symbol
 
     public:
 


### PR DESCRIPTION
- Fixes `easy_profiler_core` build on emscripten.
- Reduces warnings on Windows.