### PR TITLE
Fix typo in sample/main.cpp

### DIFF
--- a/sample/main.cpp
+++ b/sample/main.cpp
@@ -233,8 +233,8 @@ int main(int argc, char* argv[])
     }
 
     std::cout << "Objects count: " << OBJECTS << std::endl;
-    std::cout << "Render steps: " << MODELLING_STEPS << std::endl;
-    std::cout << "Modelling steps: " << RENDER_STEPS << std::endl;
+    std::cout << "Render steps: " << RENDER_STEPS << std::endl;
+    std::cout << "Modelling steps: " << MODELLING_STEPS << std::endl;
     std::cout << "Resource loading count: " << RESOURCE_LOADING_COUNT << std::endl;
 
     auto start = std::chrono::system_clock::now();


### PR DESCRIPTION
I've corrected a typo in sample/main.cpp.

Changed the code from:

std::cout << "Render steps: " << MODELLING_STEPS << std::endl;
std::cout << "Modelling steps: " << RENDER_STEPS << std::endl;

to:

std::cout << "Render steps: " << RENDER_STEPS << std::endl;
std::cout << "Modelling steps: " << MODELLING_STEPS << std::endl;
