### PR TITLE
ROS 2 Integration

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>easy_profiler</name>
+  <version>2.1.0</version>
+  <author email="unkown@todo.com">Sergey Yagovtsev</author>
+  <maintainer email="unkown@todo.com">Sergey Yagovtsev</maintainer>
+  <description>Lightweight profiler library for c++</description>
+  <url type="website">https://github.com/yse/easy_profiler</url>
+  <license>MIT</license>
+
+  <buildtool_depend>cmake</buildtool_depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
If you'd like easy_profiler to work out of the box with common robotics toolchains, feel free to merge this PR or adjust the newly added package.xml as needed.

The package.xml identifies the project as a ROS 2 package. This allows easy_installer to be built directly within a colcon workspace, which is the standard build system used in ROS 2, the most widely adopted framework for developing robotics applications.

One note: when you update your library version, you should update the version in the package.xml file as well.

Best,
Alex