### PR TITLE
Remove Qt6Compat5

### DIFF
--- a/profiler_gui/CMakeLists.txt
+++ b/profiler_gui/CMakeLists.txt
@@ -5,7 +5,6 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 find_package(Qt6Widgets)
-find_package(Qt6Core5Compat)
 
 if (Qt6Widgets_FOUND)
     message(STATUS "Using Qt v${Qt6Widgets_VERSION}")
@@ -71,7 +70,7 @@ if (Qt6Widgets_FOUND)
         resources.qrc
         resources.rc
     )
-    target_link_libraries(profiler_gui Qt6::Widgets Qt6::Core5Compat easy_profiler)
+    target_link_libraries(profiler_gui Qt6::Widgets easy_profiler)
     if (WIN32)
         target_compile_definitions(profiler_gui PRIVATE -D_WIN32_WINNT=0x0600)
     endif ()

--- a/profiler_gui/descriptors_tree_widget.cpp
+++ b/profiler_gui/descriptors_tree_widget.cpp
@@ -74,7 +74,7 @@
 #include <QToolBar>
 #include <QVariant>
 #include <QVBoxLayout>
-#include <QRegExp>
+#include <QRegularExpression>
 
 #include "descriptors_tree_widget.h"
 
@@ -553,8 +553,8 @@ void DescriptorsTreeWidget::build()
             if (p.item == nullptr)
             {
                 auto item = new DescriptorsTreeItem(0);
-                auto fullName = QString(desc->file()).remove(QRegExp("^(\\.{2}\\\\+)+").pattern()); // without leading "..\"
-                auto fileName = QString(desc->file()).remove(QRegExp("^(.+(\\\\|\\/)+)+").pattern());
+                auto fullName = QString(desc->file()).remove(QRegularExpression("^(\\.{2}\\\\+)+")); // without leading "..\"
+                auto fileName = QString(desc->file()).remove(QRegularExpression("^(.+(\\\\|\\/)+)+"));
                 auto dir = fullName.left(fullName.length() - fileName.length());
 
                 if (count == 1)

--- a/profiler_gui/globals.cpp
+++ b/profiler_gui/globals.cpp
@@ -79,6 +79,7 @@ Globals::Fonts::Fonts()
 
 Globals::Globals()
     : theme("default")
+    , text_encoding("UTF-8")
     , pid(0)
     , begin_time(0)
     , selected_thread(0U)

--- a/profiler_gui/globals.h
+++ b/profiler_gui/globals.h
@@ -58,7 +58,8 @@
 #include <string>
 #include <QObject>
 #include <QColor>
-#include <QTextCodec>
+#include <QStringDecoder>
+#include <QStringConverter>
 #include <QSize>
 #include <QFont>
 #include "common_functions.h"
@@ -96,10 +97,7 @@ namespace profiler_gui {
     //////////////////////////////////////////////////////////////////////////
 
     template <class T>
-    inline auto toUnicode(const T& _inputString) -> decltype(QTextCodec::codecForLocale()->toUnicode(_inputString))
-    {
-        return QTextCodec::codecForLocale()->toUnicode(_inputString);
-    }
+    QString toUnicode(const T& _inputString);
 
     //////////////////////////////////////////////////////////////////////////
 
@@ -203,6 +201,7 @@ namespace profiler_gui {
         EasyBlocks                            gui_blocks; ///< Profiler graphics blocks builded by GUI
 
         QString                                    theme; ///< Current UI theme name
+        QString                            text_encoding; ///< Selected text encoding for profile block names
         QString                              lastFileDir;
         Fonts                                       font; ///< Fonts
 
@@ -265,6 +264,15 @@ namespace profiler_gui {
         Globals();
 
     }; // END of struct Globals.
+
+    template <class T>
+    inline QString toUnicode(const T& _inputString)
+    {
+        QStringDecoder decoder(Globals::instance().text_encoding.toUtf8().constData());
+        if (!decoder.isValid())
+            decoder = QStringDecoder(QStringDecoder::Utf8);
+        return decoder.decode(QByteArray(_inputString));
+    }
 
     //////////////////////////////////////////////////////////////////////////
 

--- a/profiler_gui/main_window.cpp
+++ b/profiler_gui/main_window.cpp
@@ -85,7 +85,8 @@
 #include <QLabel>
 #include <QLineEdit>
 #include <QPushButton>
-#include <QTextCodec>
+#include <QStringConverter>
+#include <QStringDecoder>
 #include <QPlainTextEdit>
 #include <QTextStream>
 #include <QToolBar>
@@ -873,18 +874,16 @@ MainWindow::MainWindow() : Parent(), m_theme("default"), m_lastAddress("localhos
     actionGroup = new QActionGroup(this);
     actionGroup->setExclusive(true);
 
-    auto default_codec_mib = QTextCodec::codecForLocale()->mibEnum();
+    const QString& default_encoding = EASY_GLOBALS.text_encoding;
     {
         QList<QAction*> actions;
 
-        for (int mib : QTextCodec::availableMibs())
+        for (const QString& codec : QStringConverter::availableCodecs())
         {
-            auto codec = QTextCodec::codecForMib(mib)->name();
-
             action = new QAction(codec, actionGroup);
-            action->setData(mib);
+            action->setData(codec);
             action->setCheckable(true);
-            if (mib == default_codec_mib)
+            if (codec == default_encoding)
                 action->setChecked(true);
 
             actions.push_back(action);
@@ -1415,10 +1414,7 @@ void MainWindow::onEncodingChanged(bool)
     if (action == nullptr)
         return;
 
-    const int mib = action->data().toInt();
-    auto codec = QTextCodec::codecForMib(mib);
-    if (codec != nullptr)
-        QTextCodec::setCodecForLocale(codec);
+    EASY_GLOBALS.text_encoding = action->data().toString();
 }
 
 void MainWindow::onRulerTextPosChanged(bool)
@@ -1860,9 +1856,10 @@ void MainWindow::loadSettings()
         EASY_GLOBALS.enable_statistics = flag.toBool();
 
     QString encoding = settings.value("encoding", "UTF-8").toString();
-    auto default_codec_mib = QTextCodec::codecForName(encoding.toStdString().c_str())->mibEnum();
-    auto default_codec = QTextCodec::codecForMib(default_codec_mib);
-    QTextCodec::setCodecForLocale(default_codec);
+    QStringDecoder decoder(encoding.toUtf8().constData());
+    EASY_GLOBALS.text_encoding = decoder.isValid()
+        ? encoding
+        : QStringConverter::nameForEncoding(QStringConverter::Utf8);
 
     auto theme = settings.value("theme");
     if (theme.isValid())
@@ -1964,7 +1961,7 @@ void MainWindow::saveSettingsAndGeometry()
     settings.setValue("fps_widget_line_width", EASY_GLOBALS.fps_widget_line_width);
     settings.setValue("use_custom_window_header", EASY_GLOBALS.use_custom_window_header);
     settings.setValue("is_right_window_header_controls", EASY_GLOBALS.is_right_window_header_controls);
-    settings.setValue("encoding", QTextCodec::codecForLocale()->name());
+    settings.setValue("encoding", EASY_GLOBALS.text_encoding);
     settings.setValue("theme", m_theme);
 
     settings.endGroup();

--- a/profiler_gui/text_highlighter.cpp
+++ b/profiler_gui/text_highlighter.cpp
@@ -50,7 +50,6 @@
 
 #include "text_highlighter.h"
 #include <QColor>
-#include <QRegExp>
 
 #include <easy/details/profiler_colors.h>
 #include "common_functions.h"
@@ -87,15 +86,14 @@ void TextHighlighter::highlightBlock(const QString& text)
         return;
     }
 
-    QRegExp expression(m_pattern, m_caseSensitivity);
-    int index = text.indexOf(expression.pattern());
+    int index = text.indexOf(m_pattern, 0, m_caseSensitivity);
     while (index >= 0)
     {
-        const auto length = expression.cap().length();
+        const auto length = m_pattern.length();
         setFormat(index, length, m_textCharFormat);
 
         auto prevIndex = index;
-        index = text.indexOf(expression.pattern(), index + length);
+        index = text.indexOf(m_pattern, index + length, m_caseSensitivity);
         if (index <= prevIndex)
         {
             break;


### PR DESCRIPTION
## Summary

Removes the **Qt6 Core5Compat** dependency from `profiler_gui` by replacing deprecated Qt5-compat APIs with native Qt6 equivalents.

## Changes

- **Build:** Dropped `find_package(Qt6Core5Compat)` and linking against `Qt6::Core5Compat` in `profiler_gui/CMakeLists.txt`.
- **Text encoding:** Replaced `QTextCodec` with `QStringDecoder` / `QStringConverter`. Encoding is now stored in `EASY_GLOBALS.text_encoding` and used by `toUnicode()`, instead of changing the process-wide locale codec.
- **Encoding UI/settings:** The encoding menu, load, and save paths use the selected encoding name (default `UTF-8`) rather than MIB-based `QTextCodec` APIs.
- **Regex:** Switched `QRegExp` to `QRegularExpression` in `descriptors_tree_widget.cpp`.
- **Highlighter:** Simplified `TextHighlighter` to use `QString::indexOf` with the pattern string instead of `QRegExp`.

## Why

Qt6 Core5Compat was only needed for Qt5 APIs (`QTextCodec`, `QRegExp`). Removing it simplifies the Qt6 build and aligns the GUI with current Qt6 APIs.