### PR TITLE
Fixes for building and running on Linux

### DIFF
--- a/profiler_gui/blocks_graphics_view.cpp
+++ b/profiler_gui/blocks_graphics_view.cpp
@@ -21,7 +21,7 @@
 *                   :
 *                   : * 2016/09/15 Victor Zarubkin: Moved sources of GraphicsBlockItem and GraphicsRulerItem to separate files.
 *                   :
-*                   : * 
+*                   : *
 * ----------------- :
 * license           : Lightweight profiler library for c++
 *                   : Copyright(C) 2016-2019  Sergey Yagovtsev, Victor Zarubkin
@@ -899,7 +899,7 @@ void BlocksGraphicsView::setTree(const profiler::thread_blocks_tree_t& _blocksTr
 
         auto timestart = m_beginTime;
         auto timefinish = finish;
-        
+
         if (!t.children.empty())
             timestart = easyBlocksTree(t.children.front()).node->begin();
         if (!t.sync.empty())
@@ -956,7 +956,7 @@ void BlocksGraphicsView::setTree(const profiler::thread_blocks_tree_t& _blocksTr
 
         // fill scene with new items
         qreal h = 0, x = 0;
-        
+
         if (!t.children.empty())
             x = time2position(easyBlocksTree(t.children.front()).node->begin());
         else if (!t.sync.empty())
@@ -2070,7 +2070,7 @@ void BlocksGraphicsView::resizeEvent(QResizeEvent* event)
     Parent::resizeEvent(event);
 
     const QRectF previousRect = m_visibleSceneRect;
-    const int vbar_width = updateVisibleSceneRect(); // Update scene visible rect only once    
+    const int vbar_width = updateVisibleSceneRect(); // Update scene visible rect only once
 
     // Update slider width for scrollbar
     const auto windowWidth = (m_visibleSceneRect.width() + vbar_width) / m_scale;
@@ -3286,7 +3286,7 @@ void ThreadNamesWidget::mousePressEvent(QMouseEvent* _event)
 {
     m_idleTime = 0;
 
-    QMouseEvent e(_event->type(), _event->pos() - QPointF(sceneRect().width(), 0), _event->button(), _event->buttons() & ~Qt::RightButton, _event->modifiers());
+    QMouseEvent e(_event->type(), _event->position() - QPointF(sceneRect().width(), 0), _event->globalPosition(), _event->button(), _event->buttons() & ~Qt::RightButton, _event->modifiers());
     m_view->mousePressEvent(&e);
     _event->accept();
 }
@@ -3325,7 +3325,7 @@ void ThreadNamesWidget::mouseReleaseEvent(QMouseEvent* _event)
 {
     m_idleTime = 0;
 
-    QMouseEvent e(_event->type(), _event->pos() - QPointF(sceneRect().width(), 0), _event->button(), _event->buttons() & ~Qt::RightButton, _event->modifiers());
+    QMouseEvent e(_event->type(), _event->position() - QPointF(sceneRect().width(), 0), _event->globalPosition(), _event->button(), _event->buttons() & ~Qt::RightButton, _event->modifiers());
     m_view->mouseReleaseEvent(&e);
     _event->accept();
 }
@@ -3334,7 +3334,7 @@ void ThreadNamesWidget::mouseMoveEvent(QMouseEvent* _event)
 {
     m_idleTime = 0;
 
-    QMouseEvent e(_event->type(), _event->pos() - QPointF(sceneRect().width(), 0), _event->button(), _event->buttons() & ~Qt::RightButton, _event->modifiers());
+    QMouseEvent e(_event->type(), _event->position() - QPointF(sceneRect().width(), 0), _event->globalPosition(), _event->button(), _event->buttons() & ~Qt::RightButton, _event->modifiers());
     m_view->mouseMoveEvent(&e);
     _event->accept();
 }

--- a/profiler_gui/common_functions.cpp
+++ b/profiler_gui/common_functions.cpp
@@ -92,7 +92,7 @@ static QString arrayToString(const profiler::ArbitraryValue& _serializedValue, i
         }
 
         case profiler::DataType::Char:   return QChar(_serializedValue.toArray<char>  ()->at(_index));
-        case profiler::DataType::Int8:   return QChar(_serializedValue.toArray<int8_t>()->at(_index));
+        case profiler::DataType::Int8:   return toString<int8_t>  (_serializedValue, _index);
         case profiler::DataType::Uint8:  return toString<uint8_t> (_serializedValue, _index);
         case profiler::DataType::Int16:  return toString<int16_t> (_serializedValue, _index);
         case profiler::DataType::Uint16: return toString<uint16_t>(_serializedValue, _index);
@@ -113,7 +113,7 @@ static QString singleValueToString(const profiler::ArbitraryValue& _serializedVa
     {
         case profiler::DataType::Bool:   return _serializedValue.toValue<bool>()->value() ? QStringLiteral("true") : QStringLiteral("false");
         case profiler::DataType::Char:   return QChar(_serializedValue.toValue<char>  ()->value());
-        case profiler::DataType::Int8:   return QChar(_serializedValue.toValue<int8_t>()->value());
+        case profiler::DataType::Int8:   return toString<int8_t>  (_serializedValue);
         case profiler::DataType::Uint8:  return toString<uint8_t> (_serializedValue);
         case profiler::DataType::Int16:  return toString<int16_t> (_serializedValue);
         case profiler::DataType::Uint16: return toString<uint16_t>(_serializedValue);

--- a/profiler_gui/dialog.cpp
+++ b/profiler_gui/dialog.cpp
@@ -83,9 +83,9 @@ Dialog::Dialog(QWidget* parent, const QString& title, QWidget* content, WindowHe
     mainLayout->addWidget(m_header, 0, Qt::AlignTop);
     mainLayout->addWidget(content, 1);
 
-    auto buttonsLayout = new QHBoxLayout(m_buttonBox);
     if (buttons != QMessageBox::NoButton)
     {
+        auto buttonsLayout = new QHBoxLayout(m_buttonBox);
         buttonsLayout->addStretch(1);
         createButtons(buttonsLayout, buttons);
         mainLayout->addWidget(m_buttonBox, 0, Qt::AlignBottom);
@@ -171,7 +171,7 @@ QPushButton* Dialog::createStandardButton(QMessageBox::StandardButton id)
 {
     QString text;
     auto role = QDialogButtonBox::RejectRole;
-    
+
     switch (id)
     {
         case QMessageBox::Ok:
@@ -254,7 +254,7 @@ QPushButton* Dialog::createStandardButton(QMessageBox::StandardButton id)
         m_acceptRoleButton = id;
     else if (isNegativeRole(role) && m_rejectRoleButton == QMessageBox::NoButton)
         m_rejectRoleButton = id;
-    
+
     auto button = new QPushButton(text);
     button->setProperty("id", static_cast<int>(id));
     button->setProperty("role", static_cast<int>(role));

--- a/profiler_gui/globals.cpp
+++ b/profiler_gui/globals.cpp
@@ -54,6 +54,8 @@
 
 #include "globals.h"
 
+#include <QApplication>
+
 //////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////
 
@@ -100,7 +102,7 @@ Globals::Globals()
     , time_units(TimeUnits_ms)
     , connected(false)
     , has_local_changes(false)
-    , use_custom_window_header(true)
+    , use_custom_window_header(QApplication::platformName() != "wayland")
     , is_right_window_header_controls(true)
     , fps_enabled(true)
     , use_decorated_thread_name(false)

--- a/profiler_gui/round_progress_widget.cpp
+++ b/profiler_gui/round_progress_widget.cpp
@@ -312,7 +312,7 @@ void RoundProgressIndicator::setBackground(QColor color)
 
 void RoundProgressIndicator::setBackground(QString color)
 {
-    m_background.setNamedColor(color);
+    m_background.fromString(color);
     update();
 }
 
@@ -329,7 +329,7 @@ void RoundProgressIndicator::setColor(QColor color)
 
 void RoundProgressIndicator::setColor(QString color)
 {
-    m_color.setNamedColor(color);
+    m_color.fromString(color);
     update();
 }
 
@@ -356,7 +356,7 @@ void RoundProgressIndicator::setButtonColor(QColor color)
 
 void RoundProgressIndicator::setButtonColor(QString color)
 {
-    m_buttonColor.setNamedColor(color);
+    m_buttonColor.fromString(color);
 
     if (m_buttonStyle == NoButton)
     {
@@ -831,7 +831,7 @@ void RoundProgressDialog::setBorderRadius(int radius)
 
 void RoundProgressDialog::setBackground(QString color)
 {
-    m_background.setNamedColor(color);
+    m_background.fromString(color);
     update();
 }
 

--- a/profiler_gui/window_header.cpp
+++ b/profiler_gui/window_header.cpp
@@ -226,7 +226,7 @@ void WindowHeader::mouseDoubleClickEvent(QMouseEvent* /*event*/)
 
 void WindowHeader::mousePressEvent(QMouseEvent* event)
 {
-    m_mousePressPos = mapFromGlobal(event->globalPos());
+    m_mousePressPos = mapFromGlobal(event->globalPosition().toPoint());
 }
 
 void WindowHeader::mouseReleaseEvent(QMouseEvent* /*event*/)
@@ -242,7 +242,7 @@ void WindowHeader::mouseMoveEvent(QMouseEvent* event)
 
     if (m_isDragging)
     {
-        parentWidget()->move(event->globalPos() - m_mousePressPos);
+        parentWidget()->move(event->globalPosition().toPoint() - m_mousePressPos);
         return;
     }
 
@@ -255,7 +255,7 @@ void WindowHeader::mouseMoveEvent(QMouseEvent* event)
     if (m_closeButton != nullptr && m_closeButton->underMouse())
         return;
 
-    const auto pos = mapFromGlobal(event->globalPos());
+    const auto pos = mapFromGlobal(event->globalPosition().toPoint());
     const auto line = m_mousePressPos - pos;
     if (line.manhattanLength() > 5)
     {
@@ -270,7 +270,7 @@ void WindowHeader::mouseMoveEvent(QMouseEvent* event)
 
             const auto k = static_cast<qreal>(pos.x()) / static_cast<qreal>(w);
             const int xlocal = static_cast<int>(static_cast<qreal>(parent->width()) * k);
-            const int xglobal = event->globalPos().x() - xlocal;
+            const int xglobal = event->globalPosition().toPoint().x() - xlocal;
             parent->move(xglobal, parent->y());
 
             m_mousePressPos = QPoint(xlocal, static_cast<int>(pos.y() * k));


### PR DESCRIPTION
Use toString() function instead of toArray() for data type of Int8. The toArray() function is not supported when int8_t is distinct from char.

Fixed uses of deprecated functions. These throw compiler warnings for now, and may break for later versions if those functions are removed.

The use_custom_window_header global setting is now set to false when running on Wayland. As the display protocol doesn't support placing or moving windows on the application side, the custom header is almost entirely non-functional.

Fixes #221